### PR TITLE
Enumerate questions

### DIFF
--- a/directives/abstract_exercise.py
+++ b/directives/abstract_exercise.py
@@ -10,6 +10,14 @@ def choice_truefalse(argument):
     """
     return directives.choice(argument, ('true', 'false', 'True', 'False'))
 
+
+def choice_enumerate(argument):
+    """Choice of "numeric" or "alphabet".
+    Used in the enumeration of choices in pick-any and pick-one directives.
+    """
+    return directives.choice(argument, ('numeric', 'alphabet'))
+
+
 def str_to_bool(string, error_msg_prefix=''):
     booleans = {
         'true': True,

--- a/directives/questionnaire.py
+++ b/directives/questionnaire.py
@@ -304,10 +304,14 @@ class QuestionMixin:
             if value.startswith('regexp:'):
                 compare_regexp = True
                 value = value[7:]
-            if enumeration_of_choices and not isnot:
-                line[0] = enumeration_of_choices[value] + content.strip()
-            else:
-                line[0] = content.strip()
+
+            line[0] = content.strip()
+
+            if enumeration_of_choices:
+                if value.startswith('%100%'):
+                    line[0] = enumeration_of_choices[value[5:]] + line[0]
+                else:
+                    line[0] = enumeration_of_choices[value] + line[0]
 
             # Create document elements.
             hint = aplus_nodes.html(u'div')
@@ -435,7 +439,7 @@ class Choice(QuestionMixin, Directive):
 
             if "enumerate" in self.options:
                 if self.options['enumerate'] == 'numeric':
-                    prefix = str(i+1) + ": "
+                    prefix = str(i+1) + ". "
                 else:
                     # Start over if there are more than 26 options.
                     prefix = list(string.ascii_lowercase)[i % 26] + ": "

--- a/directives/questionnaire.py
+++ b/directives/questionnaire.py
@@ -3,6 +3,7 @@
 Directives that define automatically assessed questionnaires.
 '''
 import html
+import string
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -213,7 +214,7 @@ def slicer(string_list):
 class QuestionMixin:
     ''' Common functions for all question directives. '''
     option_spec = {
-        'class' : directives.class_option,
+        'class': directives.class_option,
         'required': directives.flag,
         'key': directives.unchanged,
     }
@@ -433,9 +434,14 @@ class Choice(QuestionMixin, Directive):
                 optdata['selected'] = True
 
             if "enumerate" in self.options:
-                prefix = str(i+1) + ": "
+                if self.options['enumerate'] == 'numeric':
+                    prefix = str(i+1) + ": "
+                else:
+                    # Start over if there are more than 26 options.
+                    prefix = list(string.ascii_lowercase)[i % 26] + ": "
                 line[0] = prefix + line[0]
                 enumeration_of_choices[key] = prefix
+
             # Create document elements.
             if dropdown is None:
                 # One answer alternative as a radio button or a checkbox.
@@ -502,7 +508,7 @@ class Choice(QuestionMixin, Directive):
 class SingleChoice(Choice):
     ''' Lists options for picking the correct one. '''
 
-    # Inherit option_spec from QuestionMixin and add a key.
+    # Inherit option_spec from Choice and add a key.
     option_spec = dict(Choice.option_spec)
     option_spec['dropdown'] = directives.flag
 
@@ -521,7 +527,7 @@ class SingleChoice(Choice):
 class MultipleChoice(Choice):
     ''' Lists options for picking all the correct ones. '''
 
-    # Inherit QuestionMixin options and add a key.
+    # Inherit Choice options and add a key.
     option_spec = dict(Choice.option_spec)
     option_spec.update({
         # enable partial points for partially correct answers

--- a/directives/questionnaire.py
+++ b/directives/questionnaire.py
@@ -304,7 +304,7 @@ class QuestionMixin:
             if value.startswith('regexp:'):
                 compare_regexp = True
                 value = value[7:]
-            if enumeration_of_choices:
+            if enumeration_of_choices and not isnot:
                 line[0] = enumeration_of_choices[value] + content.strip()
             else:
                 line[0] = content.strip()


### PR DESCRIPTION
Description from Trello:
```
Currently, the feedback for  pick-any questions is provided in a bulleted list.
If a student receives feedback on multiple options, it can be difficult to identify which feedback refers to what choice.
```

This PR adds the enumerate option to pick-one and pick-any questions in questionnaires. 
The enumerate option has two possible values: numeric or alphabet.