### PR TITLE
Add the js and css implementation of the annotated directive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,11 +741,24 @@ tool called "presentation maker".
 ### 10. Annotated code blocks
 
 Code blocks may be annotated with comments for specific lines. This extension
-must be activated separately in the project conf.py
-(`extensions = ["aplus_setup", "annotated"]`).
-This extension requires custom JavaScript code and CSS styles in order to
-highlight the annotations on mouse hover in the web browser. The frontend code
-is not distributed in this repository (or anywhere).
+must be activated separately in the project by adding the following settings to
+the **conf.py** file located in the root of your course directory.
+
+```python
+extensions = ["aplus_setup", "annotated"]
+...
+include_annotated_js = True
+include_annotated_css = True
+```
+
+This directive requires a custom JavaScript and CSS implementation for
+highlighting the annotated code when the mouse hover events of the annotations
+are fired in the web browser. Therefore, we have added a default implementation
+that allow you to make use of the annotated directive without having to write
+your own JS or CSS. However, if you want to remove the default JavaScript and
+CSS implementation, you can change the value of `include_annotated_js` and
+`include_annotated_css` to `False`. By doing so, you could write your own CSS
+and JS code to interact with the annotated directive.
 
 ```
 .. annotated::

--- a/directives/static/css/annotated.css
+++ b/directives/static/css/annotated.css
@@ -1,0 +1,107 @@
+/* hover highlights for the annotated a-plus-rst directive */
+.content div.codecomment,
+.content div.container.guicomment {
+  border-radius: 7px;
+  -webkit-border-radius: 7px;
+  -khtml-border-radius: 7px;
+  -moz-border-radius: 7px;
+  border-style: solid;
+  border-width: 1px 0px 1px 0px;
+  width: 80%;
+  padding: 10px 15px 10px 15px;
+  margin: 0px 12px 12px 95px;
+  background: #d9eecf;
+  box-shadow: 2px 2px 2px 0px #bfc2a1;
+  border-color: #bfc2a1;
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+.content span.codecomment {
+  border-radius: 7px;
+  -webkit-border-radius: 7px;
+  -khtml-border-radius: 7px;
+  -moz-border-radius: 7px;
+  border-style: solid;
+  border-width: 1px 0px 1px 0px;
+  margin: 0px 1px 0px 1pxs;
+  padding: 0px 2px 1px 2px;
+  background: #d9eecf;
+  box-shadow: 1px 1px 1px 0px #bfc2a1;
+  border-color: #bfc2a1;
+  white-space: nowrap;
+}
+.content div.admonition.aside div.codecomment {
+  width: 90%;
+  font-size: 0.85em;
+}
+.content div.codecomment + p,
+.content div.guicomment + p {
+  margin-top: 18px;
+}
+.content div.codecomment.comment-now-highlighted,
+.content div.guicomment.comment-now-highlighted {
+  box-shadow: 0px 0px 3px 3px #1ea780;
+}
+.content span.codecomment.comment-now-highlighted {
+  box-shadow: 0px 0px 2px 2px #1ea780;
+}
+.content span.loc-now-highlighted,
+.content div.highlight pre span.loc-now-highlighted,
+.content pre.repl span.loc-now-highlighted,
+.content pre.repl span.loc-now-highlighted strong,
+.content pre.repl span.loc-now-highlighted em,
+.content pre.pseudocode span.loc-now-highlighted,
+.content pre.pseudocode span.loc-now-highlighted em,
+.content div.console pre span.loc-now-highlighted,
+.content div.console pre span.loc-now-highlighted em,
+.content div.animation div.loc-now-highlighted {
+  background: #bb2c02 !important;
+  color: white !important;
+}
+.content span.loc-now-highlighted.loc-now-inserted,
+.content div.highlight pre span.loc-now-highlighted.loc-now-inserted,
+.content pre.repl span.loc-now-highlighted.loc-now-inserted,
+.content pre.repl span.loc-now-highlighted.loc-now-inserted strong,
+.content pre.repl span.loc-now-highlighted.loc-now-inserted em,
+.content pre.pseudocode span.loc-now-highlighted.loc-now-inserted,
+.content pre.pseudocode span.loc-now-highlighted.loc-now-inserted em,
+.content div.console pre span.loc-now-highlighted.loc-now-inserted,
+.content div.console pre span.loc-now-highlighted.loc-now-inserted em,
+.content div.animation div.loc-now-highlighted.loc-now-inserted {
+  background: #1155cc !important;
+  font-weight: bold !important;
+  color: white !important;
+}
+.content div.codecomment.comment-now-locked {
+  box-shadow: 0px 0px 3px 3px #3e9770;
+  background: #c9debf;
+}
+.content span.codecomment.comment-now-locked {
+  box-shadow: 0px 0px 2px 2px #3e9770;
+  background: #c9debf;
+}
+.content div.highlight pre span.loc-now-locked,
+.content pre.repl span.loc-now-locked,
+.content pre.repl span.loc-now-locked strong,
+.content pre.repl span.loc-now-locked em,
+.content pre.pseudocode span.loc-now-locked,
+.content pre.pseudocode span.loc-now-locked em,
+.content div.console pre span.loc-now-locked,
+.content div.console pre span.loc-now-locked em,
+.content div.animation div.loc-now-locked {
+  background: #bb2222;
+  color: #e0e0e0;
+}
+.content div.highlight pre span.loc-now-locked.loc-now-inserted,
+.content pre.repl span.loc-now-locked.loc-now-inserted,
+.content pre.repl span.loc-now-locked.loc-now-inserted strong,
+.content pre.repl span.loc-now-locked.loc-now-inserted em,
+.content pre.pseudocode span.loc-now-locked.loc-now-inserted,
+.content pre.pseudocode span.loc-now-locked.loc-now-inserted em,
+.content div.console pre span.loc-now-locked.loc-now-inserted,
+.content div.console pre span.loc-now-locked.loc-now-inserted em,
+.content div.animation div.loc-now-locked.loc-now-inserted {
+  background: #0145cc;
+  font-weight: bold;
+  color: #e0e0e0;
+}

--- a/directives/static/js/annotated.js
+++ b/directives/static/js/annotated.js
@@ -1,0 +1,177 @@
+// Implementation adapted from the programming o1 Course 2020
+// https://grader.cs.hut.fi/static/O1_2020/_static/kurssimateriaali.js
+jQuery(function ($) {
+  const rootElement = $("body");
+  var commentPrefix = "comment-";
+  var lockedCodeComment = null;
+
+  /* Add interactive highlighters for code examples: */
+  rootElement
+    .find("div.codecomment.container, span.codecomment")
+    .filter("[class^=" + commentPrefix + "],[class*=' " + commentPrefix + "']")
+    .each(function () {
+      var commentClass = $(this)
+        .attr("class")
+        .split(" ")
+        .filter(function (className) {
+          return className.indexOf(commentPrefix) === 0;
+        });
+      if (commentClass.length != 1) {
+        console.error(
+          "Unexpected classes on code comment: " + $(this).attr("class")
+        );
+      }
+      var classBits = commentClass[0]
+        .substring(commentPrefix.length)
+        .split("-");
+      if (classBits.length != 2) {
+        console.error(
+          "Unexpected classes on code comment: " + $(this).attr("class")
+        );
+      }
+      var exampleName = classBits[0];
+      var commentNumber = classBits[1];
+      var commentID = exampleName + "-" + commentNumber;
+
+      /* find all target locations for current commentary box */
+      var matchingCodeLocations = $(
+        ".ex-" + exampleName + " .loc" + commentNumber
+      );
+      if (matchingCodeLocations.length === 0) {
+        console.error(
+          "No code locations match this comment: " + commentClass[0]
+        );
+      }
+      var targets = matchingCodeLocations.find("*").addBack();
+
+      $(this).hover(
+        /* add hover effect for each comment and associated code locations: */
+        function () {
+          // mouse enters
+
+          // To prevent clashes in content, remove lock from any other annotations with a replacement attribute (by programmatically clicking them).
+          $(".codecomment.comment-now-locked")
+            .not(this)
+            .each(function () {
+              if (this.hasAttribute("data-replacement")) {
+                $(this).click();
+                $(this).mouseleave();
+              }
+            });
+
+          if (this.hasAttribute("data-replacement")) {
+            // To prevent clashes in content with this replacement, remove lock from any and all other annotations (by programmatically clicking them).
+            $(".codecomment.comment-now-locked")
+              .not(this)
+              .each(function () {
+                $(this).click();
+              });
+
+            var replacement = $(this).attr("data-replacement");
+            var target = targets.first();
+            target.addClass("loc-now-inserted");
+            if ($(this).data("original") === undefined) {
+              console.log("SAVED");
+              $(this).data("original", target.clone());
+            }
+            target.html(replacement);
+          }
+          targets.addClass("loc-now-highlighted");
+          $(this).addClass("comment-now-highlighted");
+        },
+        function () {
+          // mouse exits
+          if (
+            this.hasAttribute("data-replacement") &&
+            !$(this).hasClass("comment-now-locked")
+          ) {
+            var originalContent = $(this).data("original");
+            targets.first().html(originalContent);
+            targets.first().removeClass("loc-now-inserted");
+          }
+          targets.removeClass("loc-now-highlighted");
+          $(this).removeClass("comment-now-highlighted");
+        }
+      );
+
+      $(this).click(
+        /* add click effect for each comment and associated code locations: */
+        function () {
+          if (lockedCodeComment === commentID) {
+            // click again to end lock
+            targets.removeClass("loc-now-locked");
+            $(this).removeClass("comment-now-locked");
+            lockedCodeComment = null;
+          } else {
+            // click to lock this and unlock everything else
+            $(".codecomment.comment-now-locked").each(function () {
+              $(this).removeClass("comment-now-locked");
+            });
+            $(".loc-now-locked").each(function () {
+              $(this).removeClass("loc-now-locked");
+            });
+            targets.addClass("loc-now-locked");
+            $(this).addClass("comment-now-locked");
+            lockedCodeComment = commentID;
+          }
+        }
+      );
+    });
+
+  /* Add interactive highlighters for gui examples: */
+  /* to be done: refactor to avoid nasty duplication with the above; also: make more generic so that it can be used with any images later  */
+  rootElement
+    .find("div.guicomment.container")
+    .filter(
+      "div[class^=" + commentPrefix + "],div[class*=' " + commentPrefix + "']"
+    )
+    .each(function () {
+      var commentClass = $(this)
+        .attr("class")
+        .split(" ")
+        .filter(function (className) {
+          return className.indexOf(commentPrefix) === 0;
+        });
+      if (commentClass.length != 1) {
+        console.error(
+          "Unexpected classes on code comment: " + $(this).attr("class")
+        );
+      }
+      var classBits = commentClass[0]
+        .substring(commentPrefix.length)
+        .split("at");
+      if (classBits.length != 2) {
+        console.error(
+          "Unexpected classes on code comment: " + $(this).attr("class")
+        );
+      }
+      var exampleName = classBits[0];
+      var commentNumber = classBits[1];
+      var commentID = exampleName + "-" + commentNumber;
+
+      /* find all target locations for current commentary box */
+      var targets = rootElement.find(
+        ".gui" + exampleName + ".container div.figure img"
+      );
+      if (targets.length === 0) {
+        console.error("No gui examples match this comment: " + commentClass[0]);
+      }
+
+      /* add hover effect for each comment and associated code locations: */
+      $(this).hover(
+        function () {
+          var path = targets.eq(0).attr("src").split("/");
+          path[path.length - 1] =
+            "gui" + exampleName + "_" + commentNumber + ".png";
+          targets.attr("src", path.join("/"));
+          $(this).addClass("comment-now-highlighted");
+        },
+        function () {
+          var path = targets.eq(0).attr("src").split("/");
+          path[path.length - 1] = "gui" + exampleName + ".png";
+          targets.attr("src", path.join("/"));
+          $(this).removeClass("comment-now-highlighted");
+        }
+      );
+    });
+});

--- a/theme/aplus/layout.html
+++ b/theme/aplus/layout.html
@@ -37,6 +37,14 @@
     <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"></script>
     {%- endif %}
 
+    {% if '_static/css/annotated.css' in css_files %}
+    <link rel="stylesheet" href="{{ pathto('_static/css/annotated.css', 1) }}" type="text/css" data-aplus="yes"/>
+    {% endif %}
+
+    {% if '_static/js/annotated.js' in script_files %}
+    <script rel="stylesheet" src="{{ pathto('_static/js/annotated.js', 1) }}" type="text/javascript" data-aplus="yes"></script>
+    {% endif %}
+
     <link rel="stylesheet" href="https://plus.cs.hut.fi/static/css/main.css" />
 
     {%- if style %}


### PR DESCRIPTION
# Description
The annotated directive has been part of the a-plus-rst tools for a
long time. However, the annotated directive required a custom
implementation of JS and CSS. Therefore, a default implementation is
added to make this directive easier to use.

It is important to note that this default implementation can be omitted
by setting the 'include_annotated_js' and 'include_annotated_cs'
parameters to False inside the conf.py file.

Side note: If the 'include_annotated_js' and 'include_annotated_cs' are
set to False or omitted from the conf.py, the user should create and add
their own CSS and JS implementation for the annotated directive.

# Testing

- [ ] I created new unit tests
- [ ] All unit tests pass
- [X] I have tested manually

<sub>First test case</sub>
![annotated](https://user-images.githubusercontent.com/10437475/94706187-91973080-034a-11eb-807c-e983194c9224.gif)
<sub>Second test case</sub>
![annotated2](https://user-images.githubusercontent.com/10437475/94706195-94922100-034a-11eb-9090-6915382eae67.gif)

# Have you updated the README or other relevant documentation?

- [X] Yes
- [ ] Not yet. I will do it next.
- [ ] Not relevant
