### PR TITLE
Change the theme's CSS and fix issue #87

### DIFF
--- a/theme/aplus/static/default.css
+++ b/theme/aplus/static/default.css
@@ -394,6 +394,8 @@ acronym {
 /* -- code displays --------------------------------------------------------- */
 
 pre {
+  color: inherit;
+  background-color: inherit;
   overflow: auto;
   overflow-y: hidden; /* fixes display issues on Chrome browsers */
 }

--- a/theme/aplus/static/default.css
+++ b/theme/aplus/static/default.css
@@ -41,25 +41,32 @@ special components. Generic and body-level rules come from the A+ system. */
 }
 
 /* Specialized admonitions use different colours */
-.admonition.success, .admonition.meta {
+.admonition.success,
+.admonition.meta {
   color: #3c763d;
   background-color: #dff0d8;
   border-color: #d6e9c6;
 }
 
-.admonition.info, .admonition.note, .admonition.seealso {
+.admonition.info,
+.admonition.note,
+.admonition.seealso {
   color: #31708f;
   background-color: #d9edf7;
   border-color: #bce8f1;
 }
 
-.admonition.warning, .admonition.caution, .admonition.attention, .admonition.admonition-todo {
+.admonition.warning,
+.admonition.caution,
+.admonition.attention,
+.admonition.admonition-todo {
   color: #8a6d3b;
   background-color: #fcf8e3;
   border-color: #faebcc;
 }
 
-.admonition.danger, .admonition.error {
+.admonition.danger,
+.admonition.error {
   color: #a94442;
   background-color: #f2dede;
   border-color: #ebccd1;
@@ -71,20 +78,22 @@ special components. Generic and body-level rules come from the A+ system. */
   border-color: #d7d7d7;
 }
 
-
 /** Add large part of basic css **/
 
 /* -- general body styles --------------------------------------------------- */
 
-div.body p, div.body dd, div.body li, div.body blockquote {
-    -moz-hyphens: auto;
-    -ms-hyphens: auto;
-    -webkit-hyphens: auto;
-    hyphens: auto;
+div.body p,
+div.body dd,
+div.body li,
+div.body blockquote {
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  -webkit-hyphens: auto;
+  hyphens: auto;
 }
 
 a.headerlink {
-    visibility: hidden;
+  visibility: hidden;
 }
 
 h1:hover > a.headerlink,
@@ -97,151 +106,159 @@ dt:hover > a.headerlink,
 caption:hover > a.headerlink,
 p.caption:hover > a.headerlink,
 div.code-block-caption:hover > a.headerlink {
-    visibility: visible;
+  visibility: visible;
 }
 
 div.body p.caption {
-    text-align: inherit;
+  text-align: inherit;
 }
 
 div.body td {
-    text-align: left;
+  text-align: left;
 }
 
 .first {
-    margin-top: 0 !important;
+  margin-top: 0 !important;
 }
 
 p.rubric {
-    margin-top: 30px;
-    font-weight: bold;
+  margin-top: 30px;
+  font-weight: bold;
 }
 
-img.align-left, .figure.align-left, object.align-left {
-    clear: left;
-    float: left;
-    margin-right: 1em;
+img.align-left,
+.figure.align-left,
+object.align-left {
+  clear: left;
+  float: left;
+  margin-right: 1em;
 }
 
-img.align-right, .figure.align-right, object.align-right {
-    clear: right;
-    float: right;
-    margin-left: 1em;
+img.align-right,
+.figure.align-right,
+object.align-right {
+  clear: right;
+  float: right;
+  margin-left: 1em;
 }
 
-img.align-center, .figure.align-center, object.align-center {
+img.align-center,
+.figure.align-center,
+object.align-center {
   display: block;
   margin-left: auto;
   margin-right: auto;
 }
 
 .align-left {
-    text-align: left;
+  text-align: left;
 }
 
 .align-center {
-    text-align: center;
+  text-align: center;
 }
 
 .align-right {
-    text-align: right;
+  text-align: right;
 }
 
 /* -- sidebars -------------------------------------------------------------- */
 
 div.sidebar {
-    margin: 0 0 0.5em 1em;
-    border: 1px solid #ddb;
-    padding: 7px 7px 0 7px;
-    background-color: #ffe;
-    width: 40%;
-    float: right;
+  margin: 0 0 0.5em 1em;
+  border: 1px solid #ddb;
+  padding: 7px 7px 0 7px;
+  background-color: #ffe;
+  width: 40%;
+  float: right;
 }
 
 p.sidebar-title {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 /* -- topics ---------------------------------------------------------------- */
 
 div.topic {
-    border: 1px solid #ccc;
-    padding: 7px 7px 0 7px;
-    margin: 10px 0 10px 0;
+  border: 1px solid #ccc;
+  padding: 7px 7px 0 7px;
+  margin: 10px 0 10px 0;
 }
 
 p.topic-title {
-    font-size: 1.1em;
-    font-weight: bold;
-    margin-top: 10px;
+  font-size: 1.1em;
+  font-weight: bold;
+  margin-top: 10px;
 }
 
 /* -- admonitions ----------------------------------------------------------- */
 
 div.body p.centered {
-    text-align: center;
-    margin-top: 25px;
+  text-align: center;
+  margin-top: 25px;
 }
 
 /* -- tables ---------------------------------------------------------------- */
 
 table.docutils {
-    border: 0;
-    border-collapse: collapse;
+  border: 0;
+  border-collapse: collapse;
 }
 
 table caption span.caption-number {
-    font-style: italic;
+  font-style: italic;
 }
 
 table caption span.caption-text {
 }
 
-table.docutils td, table.docutils th {
-    padding: 1px 8px 1px 5px;
-    border-top: 0;
-    border-left: 0;
-    border-right: 0;
-    border-bottom: 1px solid #aaa;
+table.docutils td,
+table.docutils th {
+  padding: 1px 8px 1px 5px;
+  border-top: 0;
+  border-left: 0;
+  border-right: 0;
+  border-bottom: 1px solid #aaa;
 }
 
-table.footnote td, table.footnote th {
-    border: 0 !important;
+table.footnote td,
+table.footnote th {
+  border: 0 !important;
 }
 
 th {
-    text-align: left;
-    padding-right: 5px;
+  text-align: left;
+  padding-right: 5px;
 }
 
 table.citation {
-    border-left: solid 1px gray;
-    margin-left: 1px;
+  border-left: solid 1px gray;
+  margin-left: 1px;
 }
 
 table.citation td {
-    border-bottom: none;
+  border-bottom: none;
 }
 
 table.citation .label {
-    /* Bootstrap makes labels unreadable in Sphinx bibliographies (lists of references)
-    by using white font on white background. */
-    color: #333333;
+  /* Bootstrap makes labels unreadable in Sphinx bibliographies (lists of references)
+      by using white font on white background. */
+  color: #333333;
 }
 
 /* -- figures --------------------------------------------------------------- */
 
 div.figure {
-    margin: 0.5em;
-    padding: 0.5em;
+  margin: 0.5em;
+  padding: 0.5em;
 }
 
 div.figure p.caption {
-    padding: 0.3em;
+  padding: 0.3em;
 }
 
 div.figure p.caption span.caption-number {
-    font-style: italic;
+  font-style: italic;
 }
 
 div.figure p.caption span.caption-text {
@@ -249,315 +266,326 @@ div.figure p.caption span.caption-text {
 
 /* -- field list styles ----------------------------------------------------- */
 
-table.field-list td, table.field-list th {
-    border: 0 !important;
+table.field-list td,
+table.field-list th {
+  border: 0 !important;
 }
 
 .field-list ul {
-    margin: 0;
-    padding-left: 1em;
+  margin: 0;
+  padding-left: 1em;
 }
 
 .field-list p {
-    margin: 0;
+  margin: 0;
 }
 
 .field-name {
-    -moz-hyphens: manual;
-    -ms-hyphens: manual;
-    -webkit-hyphens: manual;
-    hyphens: manual;
+  -moz-hyphens: manual;
+  -ms-hyphens: manual;
+  -webkit-hyphens: manual;
+  hyphens: manual;
 }
 
 /* -- other body styles ----------------------------------------------------- */
 
 ol.arabic {
-    list-style: decimal;
+  list-style: decimal;
 }
 
 ol.loweralpha {
-    list-style: lower-alpha;
+  list-style: lower-alpha;
 }
 
 ol.upperalpha {
-    list-style: upper-alpha;
+  list-style: upper-alpha;
 }
 
 ol.lowerroman {
-    list-style: lower-roman;
+  list-style: lower-roman;
 }
 
 ol.upperroman {
-    list-style: upper-roman;
+  list-style: upper-roman;
 }
 
 dl {
-    margin-bottom: 15px;
+  margin-bottom: 15px;
 }
 
 dd p {
-    margin-top: 0px;
+  margin-top: 0px;
 }
 
-dd ul, dd table {
-    margin-bottom: 10px;
+dd ul,
+dd table {
+  margin-bottom: 10px;
 }
 
 dd {
-    margin-top: 3px;
-    margin-bottom: 10px;
-    margin-left: 30px;
+  margin-top: 3px;
+  margin-bottom: 10px;
+  margin-left: 30px;
 }
 
-dt:target, .highlighted {
-    background-color: #fbe54e;
+dt:target,
+.highlighted {
+  background-color: #fbe54e;
 }
 
 dl.glossary dt {
-    font-weight: bold;
-    font-size: 1.1em;
+  font-weight: bold;
+  font-size: 1.1em;
 }
 
 .optional {
-    font-size: 1.3em;
+  font-size: 1.3em;
 }
 
 .sig-paren {
-    font-size: larger;
+  font-size: larger;
 }
 
 .versionmodified {
-    font-style: italic;
+  font-style: italic;
 }
 
 .system-message {
-    background-color: #fda;
-    padding: 5px;
-    border: 3px solid red;
+  background-color: #fda;
+  padding: 5px;
+  border: 3px solid red;
 }
 
-.footnote:target  {
-    background-color: #ffa;
+.footnote:target {
+  background-color: #ffa;
 }
 
 .line-block {
-    display: block;
-    margin-top: 1em;
-    margin-bottom: 1em;
+  display: block;
+  margin-top: 1em;
+  margin-bottom: 1em;
 }
 
 .line-block .line-block {
-    margin-top: 0;
-    margin-bottom: 0;
-    margin-left: 1.5em;
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-left: 1.5em;
 }
 
-.guilabel, .menuselection {
-    font-family: sans-serif;
+.guilabel,
+.menuselection {
+  font-family: sans-serif;
 }
 
 .accelerator {
-    text-decoration: underline;
+  text-decoration: underline;
 }
 
 .classifier {
-    font-style: oblique;
+  font-style: oblique;
 }
 
-abbr, acronym {
-    border-bottom: dotted 1px;
-    cursor: help;
+abbr,
+acronym {
+  border-bottom: dotted 1px;
+  cursor: help;
 }
 
 /* -- code displays --------------------------------------------------------- */
 
 pre {
-    overflow: auto;
-    overflow-y: hidden;  /* fixes display issues on Chrome browsers */
+  overflow: auto;
+  overflow-y: hidden; /* fixes display issues on Chrome browsers */
 }
 
 span.pre {
-    -moz-hyphens: none;
-    -ms-hyphens: none;
-    -webkit-hyphens: none;
-    hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  -webkit-hyphens: none;
+  hyphens: none;
 }
 
 td.linenos pre {
-    padding: 5px 0px;
-    border: 0;
-    background-color: transparent;
-    color: #aaa;
+  padding: 5px 0px;
+  border: 0;
+  background-color: transparent;
+  color: #aaa;
 }
 
 table.highlighttable {
-    margin-left: 0.5em;
+  margin-left: 0.5em;
 }
 
 table.highlighttable td {
-    padding: 0 0.5em 0 0.5em;
+  padding: 0 0.5em 0 0.5em;
 }
 
 div.code-block-caption {
-    padding: 2px 5px;
-    font-size: small;
+  padding: 2px 5px;
+  font-size: small;
 }
 
 div.code-block-caption code {
-    background-color: transparent;
+  background-color: transparent;
 }
 
 div.code-block-caption + div > div.highlight > pre {
-    margin-top: 0;
+  margin-top: 0;
 }
 
 div.code-block-caption span.caption-number {
-    padding: 0.1em 0.3em;
-    font-style: italic;
+  padding: 0.1em 0.3em;
+  font-style: italic;
 }
 
 div.code-block-caption span.caption-text {
 }
 
 div.literal-block-wrapper {
-    padding: 1em 1em 0;
+  padding: 1em 1em 0;
 }
 
 div.literal-block-wrapper div.highlight {
-    margin: 0;
+  margin: 0;
 }
 
 code.descname {
-    background-color: transparent;
-    font-weight: bold;
-    font-size: 1.2em;
+  background-color: transparent;
+  font-weight: bold;
+  font-size: 1.2em;
 }
 
 code.descclassname {
-    background-color: transparent;
+  background-color: transparent;
 }
 
-code.xref, a code {
-    background-color: transparent;
-    font-weight: bold;
+code.xref,
+a code {
+  background-color: transparent;
+  font-weight: bold;
 }
 
-h1 code, h2 code, h3 code, h4 code, h5 code, h6 code {
-    background-color: transparent;
+h1 code,
+h2 code,
+h3 code,
+h4 code,
+h5 code,
+h6 code {
+  background-color: transparent;
 }
 
 .viewcode-link {
-    float: right;
+  float: right;
 }
 
 .viewcode-back {
-    float: right;
-    font-family: sans-serif;
+  float: right;
+  font-family: sans-serif;
 }
 
 div.viewcode-block:target {
-    margin: -1px -10px;
-    padding: 0 10px;
+  margin: -1px -10px;
+  padding: 0 10px;
 }
 
 /* -- math display ---------------------------------------------------------- */
 
 img.math {
-    vertical-align: middle;
+  vertical-align: middle;
 }
 
 div.body div.math p {
-    text-align: center;
+  text-align: center;
 }
 
 span.eqno {
-    float: right;
+  float: right;
 }
 
 span.eqno a.headerlink {
-    position: relative;
-    left: 0px;
-    z-index: 1;
+  position: relative;
+  left: 0px;
+  z-index: 1;
 }
 
 div.math:hover a.headerlink {
-    visibility: visible;
+  visibility: visible;
 }
 
 /* -- printout stylesheet --------------------------------------------------- */
 
 @media print {
-    div.document,
-    div.documentwrapper,
-    div.bodywrapper {
-        margin: 0 !important;
-        width: 100%;
-    }
+  div.document,
+  div.documentwrapper,
+  div.bodywrapper {
+    margin: 0 !important;
+    width: 100%;
+  }
 
-    div.sphinxsidebar,
-    div.related,
-    div.footer,
-    #top-link {
-        display: none;
-    }
+  div.sphinxsidebar,
+  div.related,
+  div.footer,
+  #top-link {
+    display: none;
+  }
 }
 
 /* -- point of interest --------------------------------------------------- */
 
 .poi {
-    margin: 20px 0;
-    padding: 0;
-    width:inherit;
+  margin: 20px 0;
+  padding: 0;
+  width: inherit;
 }
 
 .no-poi-box {
-    margin: 0;
-    padding: 0;
-    width: inherit;
+  margin: 0;
+  padding: 0;
+  width: inherit;
 }
 
 .poi-container {
-    width:100%;
-    padding:0;
-    margin: 5px 0;
+  width: 100%;
+  padding: 0;
+  margin: 5px 0;
 }
 
 .poi-content {
-    border: 1px solid #ccc;
-    padding:15px 20px;
-    border-radius:4px;
-}   
+  border: 1px solid #ccc;
+  padding: 15px 20px;
+  border-radius: 4px;
+}
 
 .poi-title {
-    width: 80%;
-    float:left;
-    height:20px;
-    font-weight: bold;
-    font-size:1.2em;
-    padding-left:0;
-} 
+  width: 80%;
+  float: left;
+  height: 20px;
+  font-weight: bold;
+  font-size: 1.2em;
+  padding-left: 0;
+}
 
 .poi-links {
-    width:20%;
-    text-align:right;
-    float:left;
-    margin: 5px 0 0 0;
-    height:20px;
+  width: 20%;
+  text-align: right;
+  float: left;
+  margin: 5px 0 0 0;
+  height: 20px;
 }
 
 .poi-icon {
-    margin: 0 10px;
-    vertical-align: baseline;
-    height:20px;
+  margin: 0 10px;
+  vertical-align: baseline;
+  height: 20px;
 }
 
 .borderless .poi-content {
-    border: 0;
+  border: 0;
 }
 
 .poi-container.poi-content {
-    border: 1px solid #e7f2fa;
-    border-top: 2px solid #3c763d;
-    border-bottom: 2px solid #3c763d;
-    background: #ebf5e7;
+  border: 1px solid #e7f2fa;
+  border-top: 2px solid #3c763d;
+  border-bottom: 2px solid #3c763d;
+  background: #ebf5e7;
 }

--- a/theme/aplus/static/default.css
+++ b/theme/aplus/static/default.css
@@ -42,7 +42,9 @@ special components. Generic and body-level rules come from the A+ system. */
 
 /* Specialized admonitions use different colours */
 .admonition.success,
-.admonition.meta {
+.admonition.meta,
+.admonition.tip,
+.admonition.hint {
   color: #3c763d;
   background-color: #dff0d8;
   border-color: #d6e9c6;
@@ -183,12 +185,22 @@ div.topic {
   border: 1px solid #ccc;
   padding: 7px 7px 0 7px;
   margin: 10px 0 10px 0;
+  background-color: #ddf1fb;
+}
+
+div.topic a {
+  color: #33a1ff;
+  font-weight: 400;
 }
 
 p.topic-title {
   font-size: 1.1em;
   font-weight: bold;
   margin-top: 10px;
+}
+
+.topic.dl-horizontal dd {
+  margin-bottom: 0px;
 }
 
 /* -- admonitions ----------------------------------------------------------- */
@@ -465,6 +477,14 @@ code.xref,
 a code {
   background-color: transparent;
   font-weight: bold;
+}
+
+/* Change the appearance of the download role */
+a.download > code > span.pre {
+  color: #2491EE;
+  font-weight: 500;
+  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif; 
+  font-size: 14px;
 }
 
 h1 code,

--- a/theme/aplus/static/default.css
+++ b/theme/aplus/static/default.css
@@ -427,11 +427,17 @@ td.linenos pre {
 }
 
 table.highlighttable {
-  margin-left: 0.5em;
+  width: 100%;
+  margin: 0px;
 }
 
-table.highlighttable td {
-  padding: 0 0.5em 0 0.5em;
+table.highlighttable td.linenos {
+  padding: 0px;
+  width: 1.6em;
+}
+
+.linenodiv {
+  margin: -0.4em;
 }
 
 div.code-block-caption {


### PR DESCRIPTION
# Description

1. Format the css file of the Aplus theme with Prettier.
2. Fix issue #87: Conflict between the highlight.js styles and Bootstrap
3. Add tip and hint admonitions to the theme's CSS file
4. Change the colour of the download button. The current colour does not match
the theme. The new color `#2491EE` is more appealing, and keep a decent contrast.
However, the links in general should be improved in the future. 
5. Change style of the links inside the `styled-topic` and adjust the alignment of the 
topic and description of the `styled-topic`
6. Set width of the `code-block` to `100%` when it includes the `linenos` option

# Testing
1. The styles were not affected at this point, and everything was working as usual.

2.  Fix issue #87. It was tested manually. The `emacs`, `monokai`, `default`, `vim` and `perldoc` pygments styles were tested in the aplus-manual.
**emacs**
![image](https://user-images.githubusercontent.com/10437475/82812893-a5162480-9e9c-11ea-99dc-9fc8b9a63735.png)
**monokai**
![image](https://user-images.githubusercontent.com/10437475/82812962-d0990f00-9e9c-11ea-8bb7-9662a0dbcee5.png)
**default**
![image](https://user-images.githubusercontent.com/10437475/82813714-42be2380-9e9e-11ea-833f-afe18fa1faa7.png)
**vim**
![image](https://user-images.githubusercontent.com/10437475/82815099-1f48a800-9ea1-11ea-81da-410582caa417.png)
**perldoc**
![image](https://user-images.githubusercontent.com/10437475/82813797-7c8f2a00-9e9e-11ea-85f9-2dc619b968d5.png)

3. `hint` and `tip` style
![image](https://user-images.githubusercontent.com/10437475/82814796-83b73780-9ea0-11ea-821b-8c7b8b0ba2e5.png)

4. `download` button/link
![image](https://user-images.githubusercontent.com/10437475/82814408-caf0f880-9e9f-11ea-8fd9-53b5429638c1.png)

5. styled-topic
![image](https://user-images.githubusercontent.com/10437475/82812319-6e8bda00-9e9b-11ea-854f-602b3af537f7.png)

6. `code-block` with the `linenos` option now span the same width as the text in the document.
![image](https://user-images.githubusercontent.com/10437475/82814563-15727500-9ea0-11ea-8364-67cc48525ef0.png)


----
Some styles in some courses may be affected, but the impact should be minimal.

# Have you updated the README or other relevant documentation?

The documentation does not need to be updated.

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

-- [ ] I (developer) have created unit tests and the tests pass
-- [ ] I (developer) have created functional tests (Selenium tests) if applicable
-- [X] I (developer) have tested the changes manually
-- [ ] Reviewer has finished the code review
-- [ ] After the review, the developer has made changes accordingly
-- [ ] Customer/Teacher has accepted the implementation of the feature
