### PR TITLE
Set module dates from conf.py in aplusmeta directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,36 @@ Module 1 - Introduction
   :close-time: 2020-09-30 14:00
 ```
 
+Alternatively, one can also define these options in the conf.py file of the
+course in the following way.
+
+1. Add the `aplusmeta_substitutions` variable in the conf.py file.
+
+```python
+    aplusmeta_substitutions = {
+        'open01': '2020-09-10 10:01'
+    }
+```
+
+This variable is a dictionary where keys are strings and values are dates
+in the usual format (see above). In the example above, you have defined a
+shortcut text "open01" for date "2020-09-10 10:01".
+
+2. Use the shortcut texts in the aplusmeta directive in a module index.rst:
+
+```rst
+    .. aplusmeta::
+      :open-time: open01
+      :close-time: 2019-09-20 12:00
+      :late-time: 2019-12-20 09:00
+```
+
+3. When the course is compiled, the aplusmeta directive looks for substitution
+strings in the `aplusmeta_substitutions` dictionary. The substitutions can be
+named freely as long as they are not RST markup (e.g. '|open01|' will not
+work). The substitutions can be used with any option of the meta directive.
+
+
 ### 6. Active element input
 
 This creates an input field for active element.

--- a/aplus_setup.py
+++ b/aplus_setup.py
@@ -25,6 +25,7 @@ def setup(app):
     app.add_config_value('submit_title', "{config_title}", 'html')
     app.add_config_value('course_open_date', None, 'html')
     app.add_config_value('course_close_date', None, 'html')
+    app.add_config_value('aplusmeta_substitutions', {}, 'html')
     app.add_config_value('questionnaire_default_submissions', 5, 'html')
     app.add_config_value('program_default_submissions', 10, 'html')
     app.add_config_value('default_min_group_size', 1, 'html')

--- a/conf.py
+++ b/conf.py
@@ -20,6 +20,10 @@ import os
 # -- Aplus configuration --------------------------------------------------
 course_open_date = '2016-01-01'
 course_close_date = '2017-01-01'
+aplusmeta_substitutions = {
+    'open01': '2016-01-02 12:00',
+    'close01': '2016-03-01 12:00'
+}
 questionnaire_default_submissions = 5
 program_default_submissions = 10
 ae_default_submissions = 0

--- a/directives/meta.py
+++ b/directives/meta.py
@@ -1,8 +1,9 @@
+import re
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
+from sphinx.errors import SphinxError
 
 from aplus_nodes import aplusmeta
-
 
 class AplusMeta(Directive):
     ''' Injects document meta data for A+ configuration. '''
@@ -22,5 +23,94 @@ class AplusMeta(Directive):
         'introduction': directives.unchanged, # module introduction HTML
     }
 
+    # Valid date formats are the same as in function parse_date() in
+    # toc_config.py:
+    # 1. 'YYYY-MM-DD [hh[:mm[:ss]]]'
+    # 2. 'DD.MM.YYYY [hh[:mm[:ss]]]'
+    date_format = re.compile(
+        r"^(\d\d\d\d-\d\d-\d\d|\d\d.\d\d.\d\d\d\d)" # YYYY-MM-DD or DD.MM.YYYY
+        "( \d\d(:\d\d(:\d\d)?)?)?$")                # [hh[:mm[:ss]]]
+
+    # Keys in option_spec which require a date format
+    date_format_required = {
+        'open-time',
+        'read-open-time',
+        'close-time',
+        'late-time',
+    }
+
     def run(self):
+        env = self.state.document.settings.env
+        substitutions = env.config.aplusmeta_substitutions
+
+        # Substitute values of options if a corresponding string is found in
+        # the configuration variable aplusmeta_substitutions (set in conf.py).
+        # Example:
+        #     self.options['open-time'] == 'open01'
+        #     aplusmeta_substitutions['open01'] == '2020-01-03 12:00'
+        #     # Result
+        #     modified_options['open-time'] = '2020-01-03 12:00'
+        #
+        # See the section "5. Meta (exercise round settings)" in README.md.
+        for opt, value in self.options.items():
+            old_value = None
+            if value in substitutions:
+                old_value = value
+                self.options[opt] = substitutions[value]
+            if opt in AplusMeta.date_format_required:
+                self.validate_time(opt, self.options[opt], old_value)
+
         return [aplusmeta(options=self.options)]
+
+    def validate_time(self, opt, value, old_value):
+        ''' Validates the time of given option-value pair.
+
+        Parameters:
+        opt:       key of option (one of self.option_spec)
+        value:     value of option (possibly after substitution)
+        old_value: value of option before substitution, or None if substitution
+                   was not used
+
+        Raises a SphinxError if value is invalid.
+        '''
+        if AplusMeta.date_format.match(value):
+            return
+
+        # Raise a SphinxError with a helpful message.
+        source, line = self.state_machine.get_source_and_line(self.lineno)
+
+        msg1 = (
+          "{file}, line {line}, directive aplusmeta:\n"
+          "option '{name}' has a value '{value}' which is not a date or a substitution.\n"
+          "'{value}' should be one of:\n"
+          "1. A date in the format 'YYYY-MM-DD [hh[:mm[:ss]]]', e.g., '2020-01-16 16:00'\n"
+          "2. A date in the format 'DD.MM.YYYY [hh[:mm[:ss]]]', e.g., '16.01.2020 16:00'\n"
+          "3. A substitution text in variable aplusmeta_substitutions in the file\n"
+          "   conf.py. See the A-plus RST tools file README.md > Meta (exercise round \n"
+          "   settings) for reference."
+        )
+        msg2 = (
+          "{file}, line {line}, directive aplusmeta:\n"
+          "option '{name}' has the value '{old_value}' "
+          "which substitutes for value '{value}'. This was not recognised as a date.\n"
+          "Please check the variable `aplusmeta_substitutions` in the file conf.py.\n"
+          "Set the value '{value}' to either:\n"
+          "1. A date in the format 'YYYY-MM-DD [hh[:mm[:ss]]]', e.g., '2020-01-16 16:00'\n"
+          "2. A date in the format 'DD.MM.YYYY [hh[:mm[:ss]]]', e.g., '16.01.2020 16:00'\n"
+        )
+
+        if old_value is None:
+            # No substitution
+            raise SphinxError(msg1.format(
+                file=source,
+                line=line,
+                name=opt,
+                value=value))
+        else:
+            # Substitution is used
+            raise SphinxError(msg2.format(
+                file=source,
+                line=line,
+                name=opt,
+                value=value,
+                old_value=old_value))


### PR DESCRIPTION
# Description

Allow setting module dates in the aplusmeta Sphinx directive using a new conf.py variable "aplusmeta_substitutions". See the README.md file at "The meta directive..." for detailed description.

In addition, the aplusmeta directive has now a method validate_time() which raises a SphinxError if the time format is invalid. The purpose of this method is to help a course material developer by:
 (1) causing a RST compilation error at the correct line where the error occurred;
 (2) having detailed, corrective feedback in the compilation error.

This tweak was developed for Aalto University courses CS-A1141/-A1143 Data Structures and Algorithms Y (DSA Y). The reason was that these courses have two course instances and total three language versions in the same git repository. I (the developer) and lecturer Ari Korhonen <ari.korhonen@aalto.fi> has tested and approved the changes. I created the pull request because it might be useful for other courses: all module opening and closing times can be set at the same configuration file. I have attached a copy of the conf.py of DSA Y, see lines 64-114 for an example.

Sidenote 1: if you look at the attached conf.py, DSA Y also has a modified build.sh which sets the value of variable master_doc to either 'index_1141' or 'index_1143' depending on which course is compiled. The related discussion is at aplusguru@cs.aalto.fi email chain with topic " [Aplusguru #16654] CS-A1141/CS-A1143 merge". The tweak is independent of this a-plus-rst-tools pull request.

Sidenote 2: I tried to manually import https://github.com/apluslms/a-plus-rst-tools/commit/c8bbe542d22246ff882e2cea0d10ffe65d071293 into this pull request for easier merging.

# Testing

Unit tests: It seems that A+ RST tools has no unit tests.

Manual testing:
1. Edit conf.py. Set a "aplusmeta_substitutions" variable in conf.py. (See README.md.)
2. Edit an index.rst file of an A+ learning module (chapter). Apply corresponding substitutions. (See README.md.)
3. Recompile your course locally with ./docker-compile.sh .
4. Start A+ locally with ./docker-up.sh .
5. Inspect changes to dates by web browser at the usual http://localhost:8000 .

What could be affected by this changes: setting options of aplusmeta directive directly in an index.rst file should still work. A possible future issue is related to #68 : should Ariel support the feature of this pull request?

# Have you updated the README or other relevant documentation?

Yes. README.md is updated beginning from "The meta directive does not have any content..."

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [x] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [x] Customer/Teacher has accepted the implementation of the feature
