### PR TITLE
Fix crash with trilingual courses

### DIFF
--- a/lib/toc_languages.py
+++ b/lib/toc_languages.py
@@ -315,10 +315,24 @@ def join_values(lang1, val1, lang2, val2):
 
 
 def has_identical_dict_keys(d1, d2):
-    return (
-        type(d1) == type(d2) == dict
-        and len(set(d1.keys()) ^ set(d2.keys())) == 0
-    )
+    if not (type(d1) == type(d2) == dict):
+        return False
+
+    # Collect the keys of both dicts into sets and compare their differences.
+    # Keys with and without the i18n suffix are considered identical.
+    keys1 = set()
+    for k in d1:
+        if k.endswith('|i18n'):
+            keys1.add(k[:-5])
+        else:
+            keys1.add(k)
+    keys2 = set()
+    for k in d2:
+        if k.endswith('|i18n'):
+            keys2.add(k[:-5])
+        else:
+            keys2.add(k)
+    return len(keys1 ^ keys2) == 0
 
 
 def has_identical_len_and_dict_keys(l1, l2):


### PR DESCRIPTION
# Description

**What?**

Fix crash with trilingual courses.

**Why?**

Trilingual courses caused mooc-grader to crash while starting up. This was caused by a-plus-rst-tools, which generated an invalid YAML structure for these courses.

I made a pull request despite having the privileges to push to a-plus-rst-tools/master, because I haven't touched this repository before and there might be something I hadn't considered.

**How?**

`toc_languages.py` had two issues with multilingual courses.

1) `has_identical_dict_keys` returned `False` when one of the dicts already contained localized values, i.e. a key had a `|i18n` suffix. Because of this, the last branch of `join_exercise_values` would get executed, causing an extra level of localization nesting. This wasn't a problem with bilingual courses because during the first loop (when joining English and Finnish dicts) neither of the original dicts had localized values.

2) `join_keys` should return the common part of the two keys, without the language id suffix. However, this didn't work when the language id was not at the end, e.g. `chapter2_fi_linkquiz`. The new version finds the language ids properly even in the middle of the string.

Fixes apluslms/mooc-grader#96


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that `trilingual`branch of `test-course` now starts up without crashing and localized strings appear properly in all languages. Tested that the course JSON can be exported using the UI without errors, and the structure is like the one generated from the `multilang` branch. Tested the new `join_keys` implementation with many cases, such as "test_final_fi", where the "_fi" part of "_final" could cause problems in an incorrect implementation.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*