### PR TITLE
New autosave option

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,13 @@ enable_rst_file_language_detection = True
 # ref link and label modifications.
 enable_doc_link_multilang_suffix_correction = True
 enable_ref_link_multilang_suffix_correction = True
+
+# If True, autosave is enabled for all questionnaires in this course. A draft is
+# saved periodically while a student types their answer, and the latest draft
+# is automatically restored if the student leaves the exercise page and comes
+# back later. A draft does not count as a submission and does not affect
+# grading. Autosave can also be enabled for individual questionnaires.
+enable_autosave = False
 ```
 
 ### Sphinx configurations that should be modified with a-plus-rst-tools
@@ -306,6 +313,10 @@ even if the max points aren't defined in the argument. The questionnaire directi
 * `grading-mode`: which submission determines the final score for this exercise ("best" or "last"). Defaults to "best".
   If delayed feedback is used (`reveal-submission-feedback` is set to something other than "immediate"), defaults to
   "last".
+* `autosave`: If set, autosave is enabled for this exercise. A draft is saved periodically while a student types their
+  answer, and the latest draft is automatically restored if the student leaves the exercise page and comes back later.
+  A draft does not count as a submission and does not affect grading. Autosave can also be enabled for the entire
+  course in conf.py.
 
 The contents of the questionnaire directive define the questions and possible
 instructions to students.

--- a/aplus_setup.py
+++ b/aplus_setup.py
@@ -49,6 +49,7 @@ def setup(app):
     app.add_config_value('enable_ref_link_multilang_suffix_correction', False, 'html')
     app.add_config_value('reveal_submission_feedback', None, 'html')
     app.add_config_value('reveal_model_solutions', None, 'html')
+    app.add_config_value('enable_autosave', False, 'html')
 
     # Connect configuration generation to events.
     app.connect('builder-inited', toc_config.prepare)

--- a/directives/questionnaire.py
+++ b/directives/questionnaire.py
@@ -46,6 +46,7 @@ class Questionnaire(AbstractExercise):
         'reveal-submission-feedback': directives.unchanged,
         'reveal-model-solutions': directives.unchanged,
         'grading-mode': directives.unchanged,
+        'autosave': directives.flag,
     }
 
     def run(self):
@@ -171,6 +172,11 @@ class Questionnaire(AbstractExercise):
             # values, hence the attribute must not be used in randomized
             # questionnaires.
             node.attributes['data-aplus-quiz'] = 'yes'
+
+            # Autosave can be enabled for any questionnaire that has the
+            # attribute data-aplus-quiz.
+            if 'autosave' in self.options or env.config.enable_autosave:
+                node.attributes['data-aplus-autosave'] = 'yes'
 
         self.set_assistant_permissions(data)
 


### PR DESCRIPTION
# Description

**What?**

This commit adds the new `autosave` option to the `questionnaire` directive as well as `conf.py`. When enabled, the `data-aplus-autosave` attribute is inserted to the exercise HTML. This attribute is used in A+ frontend code (see the related a-plus pull request: apluslms/a-plus#901).

**Why?**

The A+ autosave feature was requested by Aalto teachers, and this RST tools update is required by the A+ update.

**How?**

If the `autosave` option is present in a `questionnaire` directive or conf.py, and the `data-aplus-quiz` attribute is present, the `data-aplus-autosave` attribute is added.


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested manually that the attribute is added correctly based on the questionnaire option and conf.py option.

**Did you test the changes in**

- [ ] Chrome
- [ ] Firefox
- [x] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [x] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*