### PR TITLE
key_without_language() reimplemented with regexp

### DIFF
--- a/lib/toc_languages.py
+++ b/lib/toc_languages.py
@@ -1,3 +1,5 @@
+import re
+
 from sphinx.errors import SphinxError
 from sphinx.util import logging
 
@@ -6,6 +8,7 @@ import lib.yaml_writer as yaml_writer
 
 logger = logging.getLogger(__name__)
 
+print("toc_languages.py: __name__ = {}".format(__name__))
 
 # Following keys may be given a default in base (first) language
 # and other language versions are allowed to omit them.
@@ -123,7 +126,7 @@ class IndexJoiner:
             self.require_identical_dict_keys(m_path, lang1, m1, lang2, m2, ACCEPTED_MODULE_DEFAULT_KEYS)
             for k,v in m1.items():
                 if k == 'key':
-                    m[k] = join_keys(lang1, v, lang2, m2.get(k, v))
+                    m[k] = self.join_keys(lang1, v, lang2, m2.get(k, v), m_path)
                 elif k in ('name', 'title'):
                     m[k] = join_values(lang1, v, lang2, m2.get(k, v))
                 elif k == 'children':
@@ -144,7 +147,8 @@ class IndexJoiner:
             c_path = path + [str(i + 1)]
             c = {}
             self.require_identical_dict_keys(c_path, lang1, c1, lang2, c2, ACCEPTED_CHILDREN_DEFAULT_KEYS)
-            key = join_keys(lang1, c1.get('key', ''), lang2, c2.get('key', ''))
+            key = self.join_keys(lang1, c1.get('key', ''), lang2,
+                                 c2.get('key', ''), c_path)
             for k,v in c1.items():
                 if k == 'key':
                     c[k] = key
@@ -221,6 +225,76 @@ class IndexJoiner:
                 else:
                     d[k + '|i18n'] = join_values(lang1, v1, lang2, v2)
 
+    def key_without_language(self, lang, key):
+        '''
+        Strips language identifiers (ids) from a key string.
+
+        Parameters:
+        lang (string): language identifier, e.g. "en" or "fi"
+        key (string): key string of an identifier in a document,
+                      e.g. "sorting_en_mergesort_mergesort_ex"
+
+        The language identifiers are separated with dash '-' or underscore '_'
+        in the key string.
+
+        Returns:
+        There are three cases of language id occurrence in a key string.
+        (a) Language id in the beginning of a key string:
+            "id_restofstring" -> return "restofstring"
+
+        (b) Language id in the middle of a key string:
+            "something_id_restofstring" -> return "something_restofstring"
+
+        (c) Language id in the end of a key string:
+            "something_id" -> return "something"
+
+        This function looks for all cases, replacing all occurrences of the
+        language identifiers.
+        '''
+
+        beginning_or_end = "(^{0}(-|_))|((-|_){0}$)".format(lang)
+        middle = "(-|_){0}(-|_)".format(lang)
+        result = re.sub(beginning_or_end, "", key)
+        result = re.sub(middle, "_", result)
+        return result
+
+
+    def join_keys(self, lang1, key1, lang2, key2, path):
+        '''
+        Joins two similar keys having different language identifiers.
+
+        Parameters:
+        lang1: one language identifier, e.g. "en"
+        lang2: another language identifier, e.g. "fi"
+        key1: key string of an identifier in a document,
+              e.g. "sorting_en_mergesort_mergesort_ex"
+        key2: key string of another identifier in a document,
+              e.g. "sorting_fi_mergesort_mergesort_ex""
+        path: list of strings depicting the location of the keys in the
+              documentation.
+              e.g. ['modules', '1', '5', '1']
+
+        Returns: unified key without language identifiers.
+        e.g. "sorting_mergesort_mergesort_ex"
+        '''
+        if key1 == key2 or key2 == '':
+            return key1
+
+        # Store keys stripped from language identifiers separately, because
+        # we want to generate a user-friendly error message having the original
+        # keys if the keys do not match.
+        key1_stripped = self.key_without_language(lang1, key1)
+        key2_stripped = self.key_without_language(lang2, key2)
+
+        if key1_stripped != key2_stripped:
+            self.raise_error(
+                ("Mismatching keys at {}:\n"
+                "Language: {} Key: {}\n"
+                "Language: {} Key: {}"
+                ).format(path_names(path), lang1, key1, lang2, key2))
+
+        return key1_stripped
+
     def require_identical_dict_keys(self, path, lang1, d1, lang2, d2, defaults=None):
         d1d2 = set(d1.keys()) - set(d2.keys()) - set(defaults or [])
         if len(d1d2) > 0:
@@ -282,41 +356,6 @@ def path_names(path, fields=None):
 def key_names(elements):
     return ', '.join(str(e.get('key', '[missing key]')) for e in elements)
 
-
-def key_without_language(lang, key):
-    separators = ('_', '-')
-    result = ""
-    i = 0
-
-    # Find segments where the language id is surrounded by separators (or end of string).
-    # Exclude them and return the remaining string.
-    while i < len(key):
-        if key[i] in separators:
-            end_index = i + len(lang) + 1
-            if key[i+1:end_index] == lang:
-                if end_index >= len(key):
-                    break
-                if key[end_index] in separators:
-                    i = end_index
-                    continue
-        result += key[i]
-        i += 1
-    return result
-
-
-def join_keys(lang1, key1, lang2, key2):
-    if key1 == key2 or key2 == '':
-        return key1
-
-    key1 = key_without_language(lang1, key1)
-    key2 = key_without_language(lang2, key2)
-
-    if key1 != key2:
-        raise SphinxError(
-            "Corresponding RST file names must match in multilingual courses:\n"
-            + key1 + "\n" + key2)
-
-    return key1
 
 
 def join_values(lang1, val1, lang2, val2):

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,26 @@
+# a-plus-rst-tools/tests
+
+This directory contains Python unit tests for A-plus RST tools.
+The tests also serve as documentation on how parts of the software should
+operate.
+
+## Prerequisites
+
+As the unit tests are run outside the Docker container apluslms/compile-rst,
+you will need:
+
+- [Python 3](https://www.python.org)
+- [Sphinx](https://www.sphinx-doc.org/)
+- [Testfixtures](https://testfixtures.readthedocs.io/en/latest/index.html)
+
+Sphinx and Testfixtures can be installes as a Python packages, e.g.
+
+```
+pip3 install sphinx testfixtures
+```
+
+See the [top level README](../README.md) for details.
+
+## Running the tests
+
+`python3 -m unittest` runs all the unit tests.

--- a/tests/test_toc_languages.py
+++ b/tests/test_toc_languages.py
@@ -1,0 +1,115 @@
+# test_toc_languages.py
+#
+# Unit tests for lib/toc_languages.py
+
+import logging
+from pathlib import Path
+import sys
+from testfixtures import LogCapture
+import unittest
+
+# A hack to import code from the parent directory.
+# https://stackoverflow.com/questions/16981921/relative-imports-in-python-3
+file = Path(__file__).resolve()
+parent, root = file.parent, file.parents[1]
+sys.path.append(str(root))
+
+import lib.toc_languages
+
+from sphinx.errors import SphinxError
+
+# Mock classes for testing IndexJoiner
+class MockConfig:
+    def __init__(self):
+        self.skip_language_inconsistencies = False
+
+class MockApp:
+    def __init__(self):
+        self.config = MockConfig()
+
+# Tests lib/toc_languages.py
+class TestTocLanguages(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        app = MockApp()
+        base_lang = 'foo'
+        base = dict()
+        cls.joiner = lib.toc_languages.IndexJoiner(app, base_lang, base)
+        cls.logger = logging.getLogger('lib.toc_languages')
+        print("logger initialized")
+
+    def test_key_without_language(self):
+        """
+        Tests IndexJoiner.key_without_language()
+        """
+        kwl = self.__class__.joiner.key_without_language
+
+        # Strip the beginning of a key string:
+        # If the original string is "en_something" and the language
+        # tag is "en", then the result is "something".
+        self.assertEqual(kwl("en", "en_something"), "something")
+
+        # Replace a language in the middle of a key string with an underscore
+        self.assertEqual(kwl("en", "foo_en_something"), "foo_something")
+
+        # String end of a key string
+        self.assertEqual(kwl("en", "something_en"), "something")
+
+        # Don't modify a key string without a language id.
+        self.assertEqual(kwl("en", "something"), "something")
+
+        # Don't modify a key string which begins with a language tag
+        # but there is no separator.
+        self.assertEqual(kwl("en", "entropy"), "entropy")
+        self.assertEqual(kwl("en", "ingen"), "ingen")
+        self.assertEqual(kwl("en", "benign"), "benign")
+
+        # Remove all occurrences of a language id
+        self.assertEqual(kwl("en", "en_foo_en_something_en"),
+            "foo_something")
+
+        # Dashes should work as separators as well, but they are replaced
+        # with underscores in the middle of the string.
+        self.assertEqual(kwl("en", "en-foo-en-something-en"),
+            "foo_something")
+
+        # Mixed dashes and underscores are processed as similar characters.
+        self.assertEqual(kwl("en", "en_foo_en-something-en"),
+            "foo_something")
+
+        # Other language ids than "en" should work.
+        self.assertEqual(kwl("se", "se_foo_se_something_se"),
+            "foo_something")
+
+    def test_join_keys(self):
+        """
+        Tests IndexJoiner.join_keys()
+        """
+        join_keys = self.__class__.joiner.join_keys
+        logger = self.__class__.logger
+
+        path = ['modules', '1', '2', '3']
+        # Equal keys are passed without modifications
+        self.assertEqual(join_keys(
+            "en", "sorting_en_mergesort_mergesort_ex",
+            "", "sorting_en_mergesort_mergesort_ex", path),
+            "sorting_en_mergesort_mergesort_ex")
+
+        # Keys with different language ids are matched
+        self.assertEqual(join_keys(
+            "en", "sorting_en_mergesort_mergesort_ex",
+            "fi", "sorting_fi_mergesort_mergesort_ex", path),
+            "sorting_mergesort_mergesort_ex", )
+
+        # Mismatching keys produce a log message with the original keys.
+        expected_log = (
+            "sphinx.lib.toc_languages WARNING\n"
+            "  Mismatching keys at modules.1.2.3:\n"
+            "Language: en Key: sorting_en_something\n"
+            "Language: fi Key: sorting_fi_different"
+        )
+        with LogCapture() as logs:
+            result = join_keys("en", "sorting_en_something", "fi",
+            "sorting_fi_different", path)
+            self.assertEqual(str(logs), expected_log)


### PR DESCRIPTION
# Description

**What?**

This pull request contains several related modifications to A+ RST Tools issue #134.
https://github.com/apluslms/a-plus-rst-tools/issues/134

1. In lib/toc_languages.py, functions key_without_language() and join_keys()
were refactored into methods in the class IndexJoiner. This is more consistent,
as there are other "join"-named methods in IndexJoiner.

2. Method key_without_language() in lib/toc_languages.py had a bug: the
function could only strip language ids of form "id_" and "id-", not "_id" or
"_id_". The bug was discovered with course the CS-A1141 Data Structures and
Algorithms Y.  The function is now reimplemented with a more flexible regular
expression.

3. Method join_keys in lib/toc_languages.py now prints a warning message
into log. The message describes the location of mismatching keys in the
documentation tree, and mismatching keys with their language identifiers.
Example:

    Mismatching keys at modules.1.2.3:
    Language: en Key: sorting_en_something
    Language: fi Key: sorting_fi_different

This should help the course material author locate the error. Moreover,
as the method now logs an error message instead of raising a SphinxError,
the compilation process can show log messages of all mismatching keys at
one compilation run, thus increasing productivity.

4. Unit test file tests/test_toc_languages.py tests the aforementioned
modified functions. The unit tests allow the A-plus RST tools developer to:
(i) easily test the functions of the software without needing to run a
    Sphinx compilation of a test material, which can take minutes;
(ii) document how the functions should respond to certain inputs.

**Why?**

A+ RST Tools could not produce a helpful error message when there was
something inconsistent with keys on multilingual courses.

**How?**

Described above.

Fixes #134


# Testing

Python unit tests are introduced to A+ RST Tools in this pull request.
There is the new directory "tests".


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [x] Other test. *(Add a description below)*
- [ ] Manual testing.

[ADD A DESCRIPTION ABOUT WHAT YOU TESTED MANUALLY]

**Did you test the changes in**

- [ ] Chrome
- [ ] Firefox
- [x] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [x] Did you modify or add new strings in the user interface?
    Original error message:
    ```
    Corresponding RST file names must match in multilingual courses:
    fi_something
    en_different
    ```
    Modified error message:
    ```
    Mismatching keys at modules.1.2.3:
    Language: en Key: sorting_en_something
    Language: fi Key: sorting_fi_different
    ```

# Programming style

- [X] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [x] Other documentation: tests/README.md

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*