### PR TITLE
interactive code better user experience improvements

### DIFF
--- a/directives/static/js/thebe.js
+++ b/directives/static/js/thebe.js
@@ -115,7 +115,11 @@ var detectLanguage = (language) => {
     if (language.indexOf('python') > -1) {
         language = "python";
     } else if (language === 'ir') {
-        language = "r"
+        language = "r";
+    } else if (language.indexOf('cpp') > -1) {
+        language = "text/x-c++src";
+    } else if (language.indexOf('c') > -1) {
+        language = "text/x-csrc";
     }
     return language;
 }


### PR DESCRIPTION
# Description
The interactive code editor had an issue with c/cpp language highlights and poor editing experience. CodeMirror indeed has better configuration options and many styles that can be configured and used.
**What?**
1. C/CPP kernel support is better checked
2. CodeMirror can be configured in thebe-config dictionary.  An example is 
thebe_config = {
  "binderUrl": "https://binder4.org.aalto.fi",
  "repository_url": "https://github.com/jupyter-xeus/xeus-cling/stable",
  "always_load": False,
  "codemirror-config": {
      'theme': 'eclipse',
      'indentUnit': "4",
      'indentWithTabs': "true",
      'electricChars': "true",
      'lineNumbers': "true"
  }
}
3. thebe.py modified to support codemirror themes (only eclipse and abcdef theme styles for now), addons (matchbrackets is working, but show-hint is not -- so it can be removed), and codemirror-config parsing and handling.
4. thebe.js modified just to get the c/cpp language name from the kernel name. That part should anyway be changed in the next releases.


# Testing


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [ X] Manual testing.

[ADD A DESCRIPTION ABOUT WHAT YOU TESTED MANUALLY]

**Did you test the changes in**

- [X ] Chrome, Edge
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**
The changes are not expected to break anything since I have changed the dependencies. 

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))
No

# Programming style
Yes

- [ ] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?

# Have you updated the README or other relevant documentation?
It is not needed, but may be interactive code-related part in the README might be altered to show how thebe-config can be used to configure codemirror.

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*