### PR TITLE
Fix crash when no exercise URL is set manually

### DIFF
--- a/aplus_setup.py
+++ b/aplus_setup.py
@@ -52,7 +52,7 @@ def setup(app):
     app.add_config_value('enable_autosave', False, 'html')
     app.add_config_value('unprotected_paths', [], 'html')
     app.add_config_value('default_exercise_url', None, 'html')
-    app.add_config_value('default_configure_url', "{scheme}://{netloc}/configure", 'html')
+    app.add_config_value('default_configure_url', None, 'html')
     app.add_config_value('course_configures', [], 'html')
 
     # Connect configuration generation to events.

--- a/directives/abstract_exercise.py
+++ b/directives/abstract_exercise.py
@@ -102,8 +102,8 @@ class ConfigurableExercise(AbstractExercise):
         if "url" not in data and env.config.default_exercise_url:
             data["url"] = env.config.default_exercise_url
 
-        if data['url']:
-            data['url'] = data['url'].format(key=name)
+        if "url" in data:
+            data["url"] = data["url"].format(key=name)
 
     def set_configure(self, data, exercise_url, files):
         if 'no-configure' in self.options:


### PR DESCRIPTION
# Description

**What?**

Fix KeyError (and SphinxError) when no exercise URL was set manually.

**Why?**

These errors cause the course build to crash.

**How?**

Fixed the code in ``abstract_exercise.py`` and ``aplus_setup.py``

Fixes #139


# Testing


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that aplus-manual works with these changes.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.


# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
