### PR TITLE
Add alternative launch button `thebe-precell-button`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1264,7 +1264,7 @@ contain any whitespace. You must also add the option `title` to the `tab-content
 will be shown in your tabs. The content of each `tab-content` can be any anything.
 
 ### 20. Interactive code
-The `thebe-button` directive and `thebe` class can be used to make python, R and
+The `thebe-button` or `thebe-precell-button` directives and `thebe` class can be used to make python, R and
 C/C++ code-blocks interactive, allowing students to edit and run code.
 This extension must be activated separately in the project by adding `"thebe"` to the `extensions` list variable in the **conf.py** file located in the root of your course directory.
 
@@ -1328,13 +1328,26 @@ The default is `4` spaces, and should be explicitly configured to change the ind
 - In addition to these, the matching braces are highlighted when one of
 (`}`, `)` or `]`) is typed.
 
-The following code snippet is an example on how you can use the `thebe` extension.
+The following code snippets are examples on how you can use the `thebe` extension. The `thebe-button` directive makes an activation button that looks good on its own, and the `thebe-precell-button` makes an activation button that looks nice when placed just before a code cell.
 
 ```rst
 :thebe-kernel: python
 
 .. thebe-button:: Custom button text (defaults to "Run code")
 
+.. code-block:: python
+  :class: thebe
+
+  a = 1
+  b = 2
+  c = a + b
+  print(c)
+```
+
+```rst
+:thebe-kernel: python
+
+.. thebe-precell-button:: Custom button text (defaults to "Activate")
 .. code-block:: python
   :class: thebe
 

--- a/directives/static/css/thebe.css
+++ b/directives/static/css/thebe.css
@@ -23,138 +23,230 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
-/* Thebelab Buttons */
-.thebe-button-container {
+
+/* || COMMON STYLES FOR LAUNCH-BUTTON INTERFACE */
+.thebe-info {
   width: 100%;
-  padding: 20pt;
   margin-bottom: 5pt;
   margin-top: 5pt;
   background-color: #dff0d8;
   border-style: solid;
-  border-color: #3a6727;
-  text-align: center
+  border-color: #aaa;
+  border-radius: 5pt;
+}
+
+.thebelab-button.thebe-launch-button {
+  font-size: .8em;
+  border: 1px black solid;
+}
+
+.thebe-status-waiting.thebe-info {
+  background-color: lightgray;
+}
+
+.thebe-status-launching.thebe-info,
+.thebe-status-building.thebe-info,
+.thebe-status-built.thebe-info,
+.thebe-status-starting.thebe-info {
+  background-color: white;
+}
+
+.thebe-status-ready.thebe-info {
+  background-color: lightblue;
+}
+
+.thebe-status-disconnected.thebe-info {
+  background-color: lightcoral;
+}
+
+.thebe-launch-button span.status {
+  font-family: monospace;
+  font-weight: bold;
+}
+
+.thebe-standalone-button-container button.thebe-launch-button div.spinner {
+  float: left;
+  margin-right: 1em;
+}
+
+.thebe-status-ready .thebe-launch-button .spinner {
+  display: none;
+}
+
+/* Loading spinner definition is at the end of this file */
+
+/* || STANDALONE BUTTONS */
+.thebe-info.thebe-standalone-button-container {
+  text-align: center;
+  display: block;
+  padding: 20pt;
+}
+
+
+/* || BUTTONS NEXT TO CODE BLOCK  */
+/* to make it fit in with code cell. */
+
+.thebe-info.thebe-precell-button-container {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0;
+  border: 2px solid #aaa;
+  border-bottom-width: 0px;
+  border-radius: 5pt 5pt 0pt 0pt;
+  text-align: center;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.thebe-status {
+  padding: 5pt 10pt;
+  font-family: 'Roboto', sans-serif;
+  font-weight: 300;
+}
+
+.thebe-controls {
+  padding: 5pt 10pt;
+}
+
+.thebe-status-ready .thebe-controls {
+  display: none;
+}
+
+/* || ALL THEBE BUTTONS */
+.thebelab-button {
+  z-index: 999;
+  display: inline-block;
+  padding: 0.35em 1.2em;
+  margin: 0px 1px;
+  border-radius: 0.12em;
+  box-sizing: border-box;
+  text-decoration: none;
+  font-family: 'Roboto', sans-serif;
+  font-weight: 300;
+  text-align: center;
+  transition: all 0.2s;
+  background-color: #dddddd;
+  border: 0.05em solid white;
+  color: #000000;
+}
+
+.thebelab-button:hover {
+  border: 0.05em solid black;
+  background-color: #fcfcfc;
 }
 
 .thebe-button-container button {
   background-color: white
 }
 
-.thebelab-button {
-    z-index: 999;
-    display: inline-block;
-    padding: 0.35em 1.2em;
-    margin: 0px 1px;
-    border-radius: 0.12em;
-    box-sizing:  border-box;
-    text-decoration: none;
-    font-family: 'Roboto', sans-serif;
-    font-weight: 300;
-    text-align: center;
-    transition: all 0.2s;
-    background-color: #dddddd;
-    border: 0.05em solid white;
-    color: #000000;
-}
+/* || CODE CELLS */
 
-.thebelab-button:hover{
-    border: 0.05em solid black;
-    background-color: #fcfcfc;
-}
-
-.thebe-launch-button {
-    height: 2.2em;
-    font-size: .8em;
-    border: 1px black solid;
-}
-
-/* Thebelab Cell */
-.thebelab-cell pre {
+.thebelab-cell {
   background: none;
+  border: 2px solid #aaa;
+  border-radius: 5pt;
+  padding-bottom: 8px;
+}
+
+.thebelab-cell:focus-within {
+  border-color: #777 !important;
 }
 
 .thebelab-cell .thebelab-input {
-    padding-left: 1em;
-    margin-bottom: .5em;
-    margin-top: .5em;
+  padding-left: 1em;
+  padding-right: 1em;
+  margin-bottom: .5em;
+  margin-top: .5em;
 }
 
 .thebelab-cell .jp-OutputArea {
-    margin-top: .5em;
-    margin-left: 1em;
+  margin-top: .5em;
+  margin-left: 1em;
+  margin-right: 1em;
 }
 
 button.thebelab-button.thebelab-run-button {
-    margin-left: 1.5em;
-    margin-bottom: .5em;
+  margin-left: 1.5em;
+  margin-bottom: .5em;
 }
 
-/* Loading button */
-button.thebe-launch-button div.spinner {
-    float: left;
-    margin-right: 1em;
+/* || CODE BLOCKS NEXT TO BUTTON  */
+/* to make them fit in with button */
+
+.thebe-precell-button-container+.thebe .thebelab-cell {
+  margin-top: 0px;
+  border-radius: 0 0 5pt 5pt;
 }
 
-/* Remove the spinner when thebelab is ready */
-.thebe-launch-button.thebe-status-ready .spinner {
-    display: none;
+.thebe-precell-button-container+.thebe .highlight>pre {
+  margin-top: 0px;
+  background: none;
+  border: 2px solid #aaa;
+  border-radius: 0 0 5pt 5pt;
 }
 
-.thebe-launch-button span.status {
-    font-family: monospace;
-    font-weight: bold;
-}
-
-.thebe-launch-button.thebe-status-ready span.status {
-    color: green;
-}
+/* || LOADING SPINNER */
 
 .spinner {
-    height: 2em;
-    text-align: center;
-    font-size: 0.7em;
+  height: 2em;
+  text-align: center;
+  font-size: 0.7em;
+}
+
+.spinner>div {
+  background-color: #F37726;
+  height: 100%;
+  width: 6px;
+  display: inline-block;
+
+  -webkit-animation: sk-stretchdelay 1.2s infinite ease-in-out;
+  animation: sk-stretchdelay 1.2s infinite ease-in-out;
+}
+
+.spinner .rect2 {
+  -webkit-animation-delay: -1.1s;
+  animation-delay: -1.1s;
+}
+
+.spinner .rect3 {
+  -webkit-animation-delay: -1.0s;
+  animation-delay: -1.0s;
+}
+
+.spinner .rect4 {
+  -webkit-animation-delay: -0.9s;
+  animation-delay: -0.9s;
+}
+
+.spinner .rect5 {
+  -webkit-animation-delay: -0.8s;
+  animation-delay: -0.8s;
+}
+
+@-webkit-keyframes sk-stretchdelay {
+
+  0%,
+  40%,
+  100% {
+    -webkit-transform: scaleY(0.4)
   }
 
-  .spinner > div {
-    background-color: #F37726;
-    height: 100%;
-    width: 6px;
-    display: inline-block;
+  20% {
+    -webkit-transform: scaleY(1.0)
+  }
+}
 
-    -webkit-animation: sk-stretchdelay 1.2s infinite ease-in-out;
-    animation: sk-stretchdelay 1.2s infinite ease-in-out;
+@keyframes sk-stretchdelay {
+
+  0%,
+  40%,
+  100% {
+    transform: scaleY(0.4);
+    -webkit-transform: scaleY(0.4);
   }
 
-  .spinner .rect2 {
-    -webkit-animation-delay: -1.1s;
-    animation-delay: -1.1s;
+  20% {
+    transform: scaleY(1.0);
+    -webkit-transform: scaleY(1.0);
   }
-
-  .spinner .rect3 {
-    -webkit-animation-delay: -1.0s;
-    animation-delay: -1.0s;
-  }
-
-  .spinner .rect4 {
-    -webkit-animation-delay: -0.9s;
-    animation-delay: -0.9s;
-  }
-
-  .spinner .rect5 {
-    -webkit-animation-delay: -0.8s;
-    animation-delay: -0.8s;
-  }
-
-  @-webkit-keyframes sk-stretchdelay {
-    0%, 40%, 100% { -webkit-transform: scaleY(0.4) }
-    20% { -webkit-transform: scaleY(1.0) }
-  }
-
-  @keyframes sk-stretchdelay {
-    0%, 40%, 100% {
-      transform: scaleY(0.4);
-      -webkit-transform: scaleY(0.4);
-    }  20% {
-      transform: scaleY(1.0);
-      -webkit-transform: scaleY(1.0);
-    }
-  }
+}

--- a/directives/static/js/thebe.js
+++ b/directives/static/js/thebe.js
@@ -64,10 +64,29 @@ var initThebe = () => {
     thebelab.on("status", function (evt, data) {
         console.log("Status changed:", data.status, data.message);
 
-        $(".thebe-launch-button ")
-            .removeClass("thebe-status-" + thebeStatus)
-            .addClass("thebe-status-" + data.status)
-            .find(".loading-text").html("<span class='launch_msg'>Launching interactive code environment: </span><span class='status'>" + data.status + "</span>");
+        // A nicer interface for the state of launch process
+        const state_dict = {
+            'launching': 'Launching',
+            'building': 'Launching',
+            'built': 'Launching',
+            'starting': 'Launching',
+            'ready': 'Active',
+            'failed': 'Error'
+        }
+
+        // Change status of topmost container
+        $(".thebe-info ")
+        .removeClass("thebe-status-" + thebeStatus)
+        .addClass("thebe-status-" + data.status)
+
+        // Write loading text into standalone button
+        $(".thebe-standalone-button-container")
+        .find(".thebe-launch-button")
+        .find(".loading-text")
+        .html(`<span class='launch_msg'>Launching interactive code environment: </span><span class='status'> ${state_dict[data.status]} </span>`);
+
+        // Write status message into button next to code cell
+        $(".thebe-status-msg ").html(state_dict[data.status]);
 
         // Now update our thebe status
         thebeStatus = data.status;

--- a/directives/thebe.py
+++ b/directives/thebe.py
@@ -250,7 +250,7 @@ class ThebeButtonNode(nodes.Element):
     def html(self):
         text = self["text"]
         return (
-            '<div class="thebe-button-container"><button title="{text}" class="thebelab-button thebe-launch-button"'
+            '<div class="thebe-info thebe-standalone-button-container thebe-status-waiting"><button class="thebelab-button thebe-launch-button"'
             'onclick="initThebe()">{text}</button></div>'.format(text=text)
         )
 
@@ -275,6 +275,54 @@ class ThebeButton(Directive):
     def run(self):
         kwargs = {"text": self.arguments[0]} if self.arguments else {}
         return [ThebeButtonNode(**kwargs)]
+
+
+class ThebePrecellButtonNode(nodes.Element):
+    """Appended to the doctree by the ThebePrecellButton directive.
+
+    Renders a nice looking activation button when placed before code cell
+    """
+
+    def __init__(self, rawsource="", *children, text="Activate", **attributes):
+        super().__init__("", text=text)
+
+    def html(self):
+        text = self["text"]
+        return (
+        '<div class="thebe-info thebe-precell-button-container thebe-status-waiting">'
+            '<div class="thebe-status">'
+                '<div class="thebe-status-icon"> </div>'
+                '<div class="thebe-status-msg">Inactive</div>'
+            '</div>'
+            '<div class="thebe-controls">'
+                f'<button class="thebelab-button thebe-launch-button" onclick="initThebe()">'
+                f'{text}'
+                '</button>'
+            '</div>'
+        '</div>'
+        )
+
+
+class ThebePrecellButton(Directive):
+    """Specify a thebe activation button that looks nice just before a code cell
+
+    Arguments
+    ---------
+    text : str (optional)
+        If provided, the button text to display
+
+    Content
+    -------
+    None
+    """
+
+    optional_arguments = 1
+    final_argument_whitespace = True
+    has_content = False
+
+    def run(self):
+        kwargs = {"text": self.arguments[0]} if self.arguments else {}
+        return [ThebePrecellButtonNode(**kwargs)]
 
 
 # Used to render an element node as HTML
@@ -304,6 +352,7 @@ def setup(app):
     app.add_config_value("thebe_config", {}, "html")
     # override=True in case Jupyter Sphinx has already been loaded
     app.add_directive("thebe-button", ThebeButton, override=True)
+    app.add_directive("thebe-precell-button", ThebePrecellButton, override=True)
 
     # Add relevant code to headers
     opts = {'data-aplus': 'yes'}
@@ -338,6 +387,17 @@ def setup(app):
         man=(skip, None),
         override=True,
     )
+
+    app.add_node(
+        ThebePrecellButtonNode,
+        html=(visit_element_html, None),
+        latex=(skip, None),
+        textinfo=(skip, None),
+        text=(skip, None),
+        man=(skip, None),
+        override=True,
+    )
+
 
     return {
         "version": __version__,


### PR DESCRIPTION
# Description

**What?**

Add a new type of button to launch interactive code cells, meant to be used just before a code cell.

**Why?**

It (subjectively) looks better, and allows students to start running code from whatever point of the page (assuming that the buttons are added before every code cell).

**How?**

Define a new directive `thebe-precell-button` and make styling work.

# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [x] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
	+ There are some low-contrast warnings in the python code-block before it is activated.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing

I tested the new buttons in Chrome and Firefox, and checked what happens
- when I click them
- when a `thebe-button` is placed far away from a code cell
- when a `thebe-precell-button` is placed just before a code cell
- when a code cell is just after a `thebe-precell-button`
- when a code cell doesn't have a `thebe-precell-button` before it.

**Did you test the changes in**

- [x] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

Mostly styling, which could behave in weird ways in situations I didn't think of.

# Translation

- [x] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))
	-	I didn't add translations for the little text that is introduced. I'm not sure how it could be done, and having English-language text next to code that is partly in English anyway seems reasonable.

# Programming style
- [ ] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
  - Not really. I think changing to the style guide (especially for css) should be a separate pull request.
- [x] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory
	+ **Which doc directory?** I can't find a doc directory in this repo
- [x] README.md.
- [x] Aplus Manual.
	- I'll open a pull request after this.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
