### PR TITLE
Replaces the deprecated cgi package with the html package for escaping html strings

### DIFF
--- a/directives/repl.py
+++ b/directives/repl.py
@@ -2,7 +2,7 @@
 import docutils
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
-from cgi import escape
+from html import escape
 import re
 
 import aplus_nodes


### PR DESCRIPTION
# Description

cgi.escape was deprecated in Python 3.2 and removed in Python 3.8. The suggested workaround is to replace it with html.escape. The only difference is in that html.escape also escapes quotes which cgi.escape did not do. This is preferred to the earlier solution.

note: The html package is already in use in other files in a-plus-rst-tools