### PR TITLE
Add float comparison tolerance parameters to freetext directive

### DIFF
--- a/directives/questionnaire.py
+++ b/directives/questionnaire.py
@@ -573,6 +573,16 @@ class MultipleChoice(Choice):
         return 'checkbox'
 
 
+def non_negative_float(argument):
+    try:
+        value = float(argument)
+        if value >= 0:
+            return value
+    except ValueError:
+        pass
+    raise SphinxError(f"{argument} is not a non-negative float")
+
+
 class FreeText(QuestionMixin, Directive):
     ''' A free text answer. '''
     has_content = True
@@ -582,6 +592,8 @@ class FreeText(QuestionMixin, Directive):
     option_spec = {
         'length': directives.positive_int,
         'height': directives.positive_int,
+        'float-rel-tol': non_negative_float,
+        'float-abs-tol': non_negative_float,
         'own-line': directives.flag,
         'main-feedback': directives.flag,
         'required': directives.flag,
@@ -595,6 +607,8 @@ class FreeText(QuestionMixin, Directive):
     def run(self):
         self.length = self.options.get('length', None)
         self.height = self.options.get('height', 1)
+        self.float_rel_tol = self.options.get('float-rel-tol', None)
+        self.float_abs_tol = self.options.get('float-abs-tol', None)
         self.position = 'place-on-own-line' if self.height > 1 or 'own-line' in self.options else 'place-inline'
 
         # Detect paragraphs: any number of plain content and correct answer including optional feedback
@@ -638,6 +652,11 @@ class FreeText(QuestionMixin, Directive):
         if len(self.arguments) > 1:
             self._validate_compare_method(self.arguments[1])
             data['compare_method'] = self.arguments[1]
+
+        if self.float_rel_tol is not None:
+            data['float_rel_tol'] = self.float_rel_tol
+        if self.float_abs_tol is not None:
+            data['float_abs_tol'] = self.float_abs_tol
 
         if config_content:
             fb = None


### PR DESCRIPTION
# Description

**What?**

Add float comparison tolerance parameters to the freetext directive, because MOOC-Grader now supports configurable relative and absolute tolerances instead of the previously hardcoded 2% relative tolerance.

Fixes #158

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that these changes work with the new changes in MOOC-Grader

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
