### PR TITLE
Add support to a new reveal rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1450,6 +1450,8 @@ the format `+<number><unit>`, where `unit` is 'd' (days), 'h' (hours) or 'm'/'mi
 ```
 * deadline_all: Revealed after the exercise deadline, and all deadline extensions granted to any student on the course.
 An additional delay can optionally be provided as an argument. See instructions above.
+* deadline_or_full_points: Same as deadline, but also revealed after the student has achieved full points from the
+exercise. An additional delay can optionally be provided as an argument. See instructions above.
 * completion: Revealed after the student has used all submissions or achieved full points from the exercise.
 
 

--- a/lib/revealrule.py
+++ b/lib/revealrule.py
@@ -77,7 +77,7 @@ def parse_reveal_rule(
                 "2. 'DD.MM.YYYY [hh[:mm[:ss]]]', e.g., '16.01.2020 16:00'\n"
             )
 
-    elif trigger in ['deadline', 'deadline_all']:
+    elif trigger in ['deadline', 'deadline_all', 'deadline_or_full_points']:
         if argument is not None:
             match = delay_format.match(argument)
             if match:
@@ -92,7 +92,7 @@ def parse_reveal_rule(
                 result['delay_minutes'] = minutes
             else:
                 reveal_rule_error(
-                    "Delay was formatted incorrectly. When using the 'deadline' or 'deadline_all'\n"
+                    "Delay was formatted incorrectly. When using the 'deadline', 'deadline_all' or 'deadline_or_full_points'\n"
                     "reveal mode, a delay can optionally be provided after the mode name. Format the\n"
                     "delay like this:\n"
                     "'+<number><unit>', where unit is 'd' (days), 'h' (hours) or 'm'/'min' (minutes)\n"
@@ -102,7 +102,7 @@ def parse_reveal_rule(
     else:
         reveal_rule_error(
             "Unexpected reveal mode. Supported modes are 'manual', 'immediate', 'time',\n"
-            "'deadline', 'deadline_all' and 'completion'.\n"
+            "'deadline', 'deadline_all', 'deadline_or_full_points' and 'completion'.\n"
         )
 
     return result


### PR DESCRIPTION
# Description

**What?**

Adds support to a new reveal rule, check https://github.com/apluslms/a-plus/pull/1220.

**Why?**

The reveal rule should be possible to be configured in conf.py etc.

**How?**

Adds the reveal rule name as a possible configuration option in revealrule.py.
Should be merged together with https://github.com/apluslms/gitmanager/pull/41.

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Set the reveal_model_solutions variable in O1's conf.py. Ran gitmanager locally. Checked in aplus course content settings that the model solution reveal rule option was updated to exercises.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [x] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [x] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
