### PR TITLE
Add support to configure module model solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,6 +798,8 @@ The aplusmeta directive does not have any content and it accepts the following o
 * `introduction`: module introduction as an HTML string
 * `reveal-submission-feedback`: default rule for revealing submission feedback. Can be overridden per exercise. See [instructions](#defining-reveal-rules).
 * `reveal-model-solutions`: default rule for revealing model solutions. Can be overridden per exercise. See [instructions](#defining-reveal-rules).
+* `model-answer`: chapter that is used as the model answer for the module in the format `<module_key>/<chapter_key>`.
+* `reveal-module-model-solution`: rule for revealing the module model solution. See [instructions](#defining-reveal-rules).
 
 Example module index.rst file:
 

--- a/directives/meta.py
+++ b/directives/meta.py
@@ -24,6 +24,8 @@ class AplusMeta(Directive):
         'introduction': directives.unchanged, # module introduction HTML
         'reveal-submission-feedback': directives.unchanged,
         'reveal-model-solutions': directives.unchanged,
+        'model-answer': directives.unchanged,
+        'reveal-module-model-solution': directives.unchanged,
     }
 
     # Valid date formats are the same as in function parse_date() in
@@ -42,10 +44,19 @@ class AplusMeta(Directive):
         'late-time',
     }
 
+    chapter_format = re.compile(
+        "^\w+\/\w+$"
+    )
+
+    chapter_format_required = {
+        'model-answer',
+    }
+
     # Keys in option_spec which are parsed as reveal rules
     reveal_rules = {
         'reveal-submission-feedback',
         'reveal-model-solutions',
+        'reveal-module-model-solution',
     }
 
     def run(self):
@@ -68,6 +79,8 @@ class AplusMeta(Directive):
                 self.options[opt] = substitutions[value]
             if opt in AplusMeta.date_format_required:
                 self.validate_time(opt, self.options[opt], old_value)
+            if opt in AplusMeta.chapter_format_required:
+                self.options[opt] = self.parse_chapter(opt, value)
             if opt in AplusMeta.reveal_rules:
                 source, line = self.state_machine.get_source_and_line(self.lineno)
                 self.options[opt] = parse_reveal_rule(value, source, line, opt)
@@ -126,3 +139,13 @@ class AplusMeta(Directive):
                 name=opt,
                 value=value,
                 old_value=old_value))
+
+    def parse_chapter(self, option: str, chapter: str):
+        if AplusMeta.chapter_format.match(chapter):
+            return chapter
+        else:
+            raise SphinxError(
+                f"Option '{option}' was formatted incorrectly: '{chapter}'.\n"
+                "Use the following format: 'module_key/chapter_key', e.g., 'module01/chapter01'."
+            )
+

--- a/toc_config.py
+++ b/toc_config.py
@@ -367,6 +367,8 @@ def make_index(app, root, language=''):
         close_src = meta.get('close-time', title_date_match.group(1) if title_date_match else course_close)
         late_src = meta.get('late-time', course_late)
         introduction = meta.get('introduction', None)
+        model_answer = meta.get('model-answer', None)
+        reveal_module_model_solution = meta.get('reveal-module-model-solution', None)
         module = {
             # modules01/index -> modules01
             # modules/01/index -> modules_01
@@ -390,6 +392,10 @@ def make_index(app, root, language=''):
             module['late_penalty'] = parse_float(meta.get('late-penalty', course_penalty), 0.0)
         if introduction is not None:
             module['introduction'] = introduction
+        if model_answer is not None:
+            module['model_answer'] = model_answer
+        if reveal_module_model_solution is not None:
+            module['reveal_module_model_solution'] = reveal_module_model_solution
         modules.append(module)
         parse_chapter(docname, doc, module['children'], meta)
 


### PR DESCRIPTION
# Description

**What?**

Adds support to configure new course module options: model answer and module solution reveal rule.
See https://github.com/apluslms/a-plus/pull/1229.
Should be merged together with https://github.com/apluslms/gitmanager/pull/51 and https://github.com/apluslms/a-plus/pull/1250.

**Why?**

Options should be able to be configured in the courses' repositories.

**How?**

Meta directive accepts new options.

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Added rst code to O1 and Aplus manual repositories that configure new course module options. Ran gitmanager and A+ locally and checked in A+ course settings that the options were saved.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [x] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [x] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
