### PR TITLE
Add option to disable duplicate submission check

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,10 @@ enable_ref_link_multilang_suffix_correction = True
 # back later. A draft does not count as a submission and does not affect
 # grading. Autosave can also be enabled for individual questionnaires.
 enable_autosave = False
+
+# If True, do not display a confirmation dialog when attempting to submit
+# identical/duplicate answers to questionnaires or submit exercises.
+disable_duplicate_check = False
 ```
 
 ### Sphinx configurations that should be modified with a-plus-rst-tools
@@ -411,6 +415,8 @@ even if the max points aren't defined in the argument. The questionnaire directi
   answer, and the latest draft is automatically restored if the student leaves the exercise page and comes back later.
   A draft does not count as a submission and does not affect grading. Autosave can also be enabled for the entire
   course in conf.py.
+* `disable-duplicate-check`: If set, do not display a confirmation dialog when attempting to submit
+  identical/duplicate answers to a questionnaire.
 
 The contents of the questionnaire directive define the questions and possible
 instructions to students.
@@ -712,6 +718,8 @@ It accepts the following options:
 * `grading-mode`: which submission determines the final score for this exercise ("best" or "last"). Defaults to "best".
   If delayed feedback is used (`reveal-submission-feedback` is set to something other than "immediate"), defaults to
   "last".
+* `disable-duplicate-check`: If set, do not display a confirmation dialog when attempting to submit
+  identical/duplicate answers to an exercise.
 * `quiz`: If set, the exercise feedback will take the place of the exercise instructions.
   This makes sense for questionnaires since their feedback contains the submission form.
   In RST, you would usually define questionnaires with the questionnaire directive,

--- a/aplus_setup.py
+++ b/aplus_setup.py
@@ -51,6 +51,7 @@ def setup(app):
     app.add_config_value('reveal_submission_feedback', None, 'html')
     app.add_config_value('reveal_model_solutions', None, 'html')
     app.add_config_value('enable_autosave', False, 'html')
+    app.add_config_value('disable_duplicate_check', False, 'html')
     app.add_config_value('unprotected_paths', [], 'html')
     app.add_config_value('default_exercise_url', None, 'html')
     app.add_config_value('default_configure_url', None, 'html')

--- a/directives/questionnaire.py
+++ b/directives/questionnaire.py
@@ -47,6 +47,7 @@ class Questionnaire(ConfigurableExercise):
         'reveal-model-solutions': directives.unchanged,
         'grading-mode': directives.unchanged,
         'autosave': directives.flag,
+        'disable-duplicate-check': directives.flag,
     })
 
     def run(self):
@@ -175,6 +176,8 @@ class Questionnaire(ConfigurableExercise):
 
         if 'autosave' in self.options or env.config.enable_autosave:
             node.attributes['data-aplus-autosave'] = 'yes'
+        if 'disable-duplicate-check' in self.options or env.config.disable_duplicate_check:
+            node.attributes['data-aplus-disable-duplicate-check'] = 'yes'
 
         self.set_assistant_permissions(data)
 

--- a/directives/submit.py
+++ b/directives/submit.py
@@ -22,6 +22,7 @@ class SubmitForm(ConfigurableExercise):
         'class' : directives.class_option,
         'quiz': directives.flag,
         'ajax': directives.flag,
+        'disable-duplicate-check': directives.flag,
         'submissions': directives.nonnegative_int,
         'points-to-pass': directives.nonnegative_int,
         'config': directives.unchanged,
@@ -65,6 +66,8 @@ class SubmitForm(ConfigurableExercise):
             args['data-aplus-quiz'] = 'yes'
         if 'ajax' in self.options:
             args['data-aplus-ajax'] = 'yes'
+        if 'disable-duplicate-check' in self.options or env.config.disable_duplicate_check:
+            args['data-aplus-disable-duplicate-check'] = 'yes'
         node = aplus_nodes.html('div', args)
 
         key_title = "{} {}".format(translations.get(env, 'exercise'), key)


### PR DESCRIPTION
# Description

**What?**

Add option to disable duplicate submission check for individual questionnaires and submit exercises or the whole course.

**Why?**

Some exercises often expect the submissions to be identical, so always showing the confirmation dialog is unnecessary.

Part of apluslms/a-plus#1076

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the new feature works as expected.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [x] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
