### PR TITLE
Check multiple-choice questionnaire for duplicate keys

### DIFF
--- a/directives/questionnaire.py
+++ b/directives/questionnaire.py
@@ -423,6 +423,7 @@ class Choice(QuestionMixin, Directive):
                 'name': 'field_{:d}'.format(env.question_count - 1),
             })
 
+        choice_keys = []
         correct_count = 0
         # Travel all answer options.
         for i,line in slicer(choices):
@@ -447,6 +448,14 @@ class Choice(QuestionMixin, Directive):
                 key = key[1:]
             if key.endswith('.'):
                 key = key[:-1]
+
+            if key in choice_keys:
+                source, line = self.state_machine.get_source_and_line(self.lineno)
+                raise SphinxError(
+                    source + ": line " + str(line) +
+                    f"\nThe choice keys in a questionnaire must be unique! Found a duplicate key: {key}"
+                )
+            choice_keys.append(key)
 
             # Add YAML configuration data.
             optdata = {


### PR DESCRIPTION
# Description

**What?**

Add validation to check that there exists no duplicate choice keys in pick-one or pick-any questionnaires, when building the course.

This pull-request has conflicting changes with PR #169, but they should be easy to resolve.

**Why?**

Duplicate choice keys are not allowed in pick-one or pick-any questionnaires, and they can cause confusing symptoms.
This was requested by a teacher.

Fixes #171

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that duplicate keys are correctly detected, and course build is stopped.

**Did you test the changes in**

- [ ] Chrome
- [ ] Firefox
- [x] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature