### PR TITLE
Add support for show-zero-points-immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -1453,7 +1453,12 @@ can be defined and overridden on multiple levels:
 * exercise level, in the `questionnaire`/`submit` directive
 
 Additionally one can define separately from the reveal mode if the user should see submissions with zero
-points immediately. Check below for usage.
+points immediately (default false).
+
+```
+:show-zero-points-immediately: true
+:show-zero-points-immediately: false
+```
 
 The reveal rules are defined by providing the name of a reveal mode. Some of the modes also accept arguments after the
 mode name. The reveal modes are:
@@ -1464,9 +1469,9 @@ mode name. The reveal modes are:
 `YYYY-MM-DD [hh[:mm[:ss]]]` or `DD.MM.YYYY [hh[:mm[:ss]]]`. Examples:
 ```
 :reveal-submission-feedback: time 2020-01-16
-:reveal-submission-feedback: time 2020-01-16 16 : show-zero-points-immediately true
+:reveal-submission-feedback: time 2020-01-16 16
 :reveal-submission-feedback: time 16.01.2020 16:00
-:reveal-submission-feedback: time 16.01.2020 16:00:00 : show-zero-points-immediately false
+:reveal-submission-feedback: time 16.01.2020 16:00:00
 ```
 * deadline: Revealed after the exercise deadline, and the possible deadline extension granted to the student. **This is
 the default setting for revealing model solutions.** An additional delay can optionally be provided as an argument, in
@@ -1474,7 +1479,7 @@ the format `+<number><unit>`, where `unit` is 'd' (days), 'h' (hours) or 'm'/'mi
 ```
 :reveal-submission-feedback: deadline
 :reveal-submission-feedback: deadline +1d
-:reveal-submission-feedback: deadline +2h : show-zero-points-immediately true
+:reveal-submission-feedback: deadline +2h
 :reveal-submission-feedback: deadline +30m
 :reveal-submission-feedback: deadline +30min
 ```

--- a/README.md
+++ b/README.md
@@ -1452,6 +1452,9 @@ can be defined and overridden on multiple levels:
 * module level, in the `aplusmeta` directive
 * exercise level, in the `questionnaire`/`submit` directive
 
+Additionally one can define separately from the reveal mode if the user should see submissions with zero
+points immediately. Check below for usage.
+
 The reveal rules are defined by providing the name of a reveal mode. Some of the modes also accept arguments after the
 mode name. The reveal modes are:
 
@@ -1461,9 +1464,9 @@ mode name. The reveal modes are:
 `YYYY-MM-DD [hh[:mm[:ss]]]` or `DD.MM.YYYY [hh[:mm[:ss]]]`. Examples:
 ```
 :reveal-submission-feedback: time 2020-01-16
-:reveal-submission-feedback: time 2020-01-16 16
+:reveal-submission-feedback: time 2020-01-16 16 : show-zero-points-immediately true
 :reveal-submission-feedback: time 16.01.2020 16:00
-:reveal-submission-feedback: time 16.01.2020 16:00:00
+:reveal-submission-feedback: time 16.01.2020 16:00:00 : show-zero-points-immediately false
 ```
 * deadline: Revealed after the exercise deadline, and the possible deadline extension granted to the student. **This is
 the default setting for revealing model solutions.** An additional delay can optionally be provided as an argument, in
@@ -1471,7 +1474,7 @@ the format `+<number><unit>`, where `unit` is 'd' (days), 'h' (hours) or 'm'/'mi
 ```
 :reveal-submission-feedback: deadline
 :reveal-submission-feedback: deadline +1d
-:reveal-submission-feedback: deadline +2h
+:reveal-submission-feedback: deadline +2h : show-zero-points-immediately true
 :reveal-submission-feedback: deadline +30m
 :reveal-submission-feedback: deadline +30min
 ```
@@ -1480,7 +1483,6 @@ An additional delay can optionally be provided as an argument. See instructions 
 * deadline_or_full_points: Same as deadline, but also revealed after the student has achieved full points from the
 exercise. An additional delay can optionally be provided as an argument. See instructions above.
 * completion: Revealed after the student has used all submissions or achieved full points from the exercise.
-
 
 ## Developers: how to debug A-plus-rst-tools and Sphinx in VS Code
 

--- a/directives/questionnaire.py
+++ b/directives/questionnaire.py
@@ -14,7 +14,7 @@ import aplus_nodes
 import lib.translations as translations
 import lib.yaml_writer as yaml_writer
 from directives.abstract_exercise import ConfigurableExercise, choice_truefalse, str_to_bool
-from lib.revealrule import parse_reveal_rule
+from lib.utils import apply_reveal_rules
 
 
 logger = logging.getLogger(__name__)
@@ -44,6 +44,7 @@ class Questionnaire(ConfigurableExercise):
         'allow-assistant-viewing': choice_truefalse,
         'allow-assistant-grading': choice_truefalse,
         'reveal-submission-feedback': directives.unchanged,
+        'show-zero-points-immediately': choice_truefalse,
         'reveal-model-solutions': directives.unchanged,
         'grading-mode': directives.unchanged,
         'autosave': directives.flag,
@@ -207,20 +208,8 @@ class Questionnaire(ConfigurableExercise):
             data['title|i18n'] = translations.opt('feedback') if is_feedback else translations.opt('exercise', postfix="{}".format(key))
 
         source, line = self.state_machine.get_source_and_line(self.lineno)
-        if 'reveal-submission-feedback' in self.options:
-            data['reveal_submission_feedback'] = parse_reveal_rule(
-                self.options['reveal-submission-feedback'],
-                source,
-                line,
-                'reveal-submission-feedback',
-            )
-        if 'reveal-model-solutions' in self.options:
-            data['reveal_model_solutions'] = parse_reveal_rule(
-                self.options['reveal-model-solutions'],
-                source,
-                line,
-                'reveal-model-solutions',
-            )
+
+        apply_reveal_rules(self.options, data, source, line)
 
         if 'grading-mode' in self.options:
             data['grading_mode'] = self.options['grading-mode']

--- a/directives/submit.py
+++ b/directives/submit.py
@@ -12,7 +12,7 @@ import aplus_nodes
 import lib.translations as translations
 import lib.yaml_writer as yaml_writer
 from directives.abstract_exercise import ConfigurableExercise, choice_truefalse
-from lib.revealrule import parse_reveal_rule
+from lib.utils import apply_reveal_rules
 
 
 class SubmitForm(ConfigurableExercise):
@@ -41,6 +41,7 @@ class SubmitForm(ConfigurableExercise):
         'allow-assistant-viewing': choice_truefalse,
         'allow-assistant-grading': choice_truefalse,
         'reveal-submission-feedback': directives.unchanged,
+        'show-zero-points-immediately': choice_truefalse,
         'reveal-model-solutions': directives.unchanged,
         'grading-mode': directives.unchanged,
     })
@@ -176,20 +177,8 @@ class SubmitForm(ConfigurableExercise):
         data.setdefault('status', self.options.get('status', 'unlisted'))
 
         source, line = self.state_machine.get_source_and_line(self.lineno)
-        if 'reveal-submission-feedback' in self.options:
-            data['reveal_submission_feedback'] = parse_reveal_rule(
-                self.options['reveal-submission-feedback'],
-                source,
-                line,
-                'reveal-submission-feedback',
-            )
-        if 'reveal-model-solutions' in self.options:
-            data['reveal_model_solutions'] = parse_reveal_rule(
-                self.options['reveal-model-solutions'],
-                source,
-                line,
-                'reveal-model-solutions',
-            )
+
+        apply_reveal_rules(self.options, data, source, line)
 
         if 'grading-mode' in self.options:
             data['grading_mode'] = self.options['grading-mode']

--- a/lib/revealrule.py
+++ b/lib/revealrule.py
@@ -54,21 +54,36 @@ def parse_reveal_rule(
 
     result: Dict[str, Any] = {'trigger': trigger}
 
-    if trigger in ['immediate', 'manual', 'completion']:
+    if trigger in ['immediate']:
         if argument is not None:
             reveal_rule_error(
                 "Unexpected argument in reveal rule. When using the 'manual', 'immediate' or\n"
                 "'completion' mode, no arguments are expected after the mode name.\n"
             )
-
+    elif trigger in ['manual', 'completion']:
+        if argument is not None:
+            time_parts = argument.split(': show-zero-points-immediately')
+            zero_points_argument = time_parts[1].strip()
+            if zero_points_argument == "true":
+                result['show_zero_points_immediately'] = True
+            else:
+                result['show_zero_points_immediately'] = False
     elif trigger == 'time':
         if argument is None:
             reveal_rule_error(
                 "Reveal time was not provided. When using the 'time' reveal mode, a time must be\n"
                 "provided after the mode name.\n"
             )
-        if date_format.match(argument):
-            result['time'] = argument
+        time_parts = argument.split(': show-zero-points-immediately ')
+        time_argument = time_parts[0].strip()
+        if date_format.match(time_argument):
+            result['time'] = time_argument
+            if len(time_parts) > 1:
+                additional_argument = time_parts[1].strip()
+                if additional_argument == "true":
+                    result['show_zero_points_immediately'] = True
+                else:
+                    result['show_zero_points_immediately'] = False
         else:
             reveal_rule_error(
                 "Reveal time was formatted incorrectly. When using the 'time' reveal mode, use\n"
@@ -79,7 +94,10 @@ def parse_reveal_rule(
 
     elif trigger in ['deadline', 'deadline_all', 'deadline_or_full_points']:
         if argument is not None:
-            match = delay_format.match(argument)
+            time_parts = argument.split(': show-zero-points-immediately ')
+            delay_argument = time_parts[0].strip()
+            match = delay_format.match(delay_argument)
+
             if match:
                 number = int(match.group('number'))
                 unit = match.group('unit')
@@ -90,6 +108,12 @@ def parse_reveal_rule(
                 else:
                     minutes = number
                 result['delay_minutes'] = minutes
+                if len(time_parts) > 1:
+                    additional_argument = time_parts[1].strip()
+                    if additional_argument == "true":
+                        result['show_zero_points_immediately'] = True
+                    else:
+                        result['show_zero_points_immediately'] = False
             else:
                 reveal_rule_error(
                     "Delay was formatted incorrectly. When using the 'deadline', 'deadline_all' or 'deadline_or_full_points'\n"

--- a/lib/revealrule.py
+++ b/lib/revealrule.py
@@ -54,36 +54,21 @@ def parse_reveal_rule(
 
     result: Dict[str, Any] = {'trigger': trigger}
 
-    if trigger in ['immediate']:
+    if trigger in ['immediate', 'manual', 'completion']:
         if argument is not None:
             reveal_rule_error(
                 "Unexpected argument in reveal rule. When using the 'manual', 'immediate' or\n"
                 "'completion' mode, no arguments are expected after the mode name.\n"
             )
-    elif trigger in ['manual', 'completion']:
-        if argument is not None:
-            time_parts = argument.split(': show-zero-points-immediately')
-            zero_points_argument = time_parts[1].strip()
-            if zero_points_argument == "true":
-                result['show_zero_points_immediately'] = True
-            else:
-                result['show_zero_points_immediately'] = False
+
     elif trigger == 'time':
         if argument is None:
             reveal_rule_error(
                 "Reveal time was not provided. When using the 'time' reveal mode, a time must be\n"
                 "provided after the mode name.\n"
             )
-        time_parts = argument.split(': show-zero-points-immediately ')
-        time_argument = time_parts[0].strip()
-        if date_format.match(time_argument):
-            result['time'] = time_argument
-            if len(time_parts) > 1:
-                additional_argument = time_parts[1].strip()
-                if additional_argument == "true":
-                    result['show_zero_points_immediately'] = True
-                else:
-                    result['show_zero_points_immediately'] = False
+        if date_format.match(argument):
+            result['time'] = argument
         else:
             reveal_rule_error(
                 "Reveal time was formatted incorrectly. When using the 'time' reveal mode, use\n"
@@ -94,10 +79,7 @@ def parse_reveal_rule(
 
     elif trigger in ['deadline', 'deadline_all', 'deadline_or_full_points']:
         if argument is not None:
-            time_parts = argument.split(': show-zero-points-immediately ')
-            delay_argument = time_parts[0].strip()
-            match = delay_format.match(delay_argument)
-
+            match = delay_format.match(argument)
             if match:
                 number = int(match.group('number'))
                 unit = match.group('unit')
@@ -108,12 +90,6 @@ def parse_reveal_rule(
                 else:
                     minutes = number
                 result['delay_minutes'] = minutes
-                if len(time_parts) > 1:
-                    additional_argument = time_parts[1].strip()
-                    if additional_argument == "true":
-                        result['show_zero_points_immediately'] = True
-                    else:
-                        result['show_zero_points_immediately'] = False
             else:
                 reveal_rule_error(
                     "Delay was formatted incorrectly. When using the 'deadline', 'deadline_all' or 'deadline_or_full_points'\n"

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -1,0 +1,30 @@
+from sphinx.errors import SphinxError
+
+from lib.revealrule import parse_reveal_rule
+from directives.abstract_exercise import str_to_bool
+
+def apply_reveal_rules(options, data, source, line):
+    if 'show-zero-points-immediately' in options:
+        if not 'reveal-submission-feedback' in options:
+            raise SphinxError(
+                source + ": line " + str(line) +
+                "\nOption 'show-zero-points-immediately' requires 'reveal-submission-feedback' to be set!"
+            )
+    if 'reveal-submission-feedback' in options:
+        data['reveal_submission_feedback'] = parse_reveal_rule(
+            options['reveal-submission-feedback'],
+            source,
+            line,
+            'reveal-submission-feedback',
+        )
+        if 'show-zero-points-immediately' in options:
+            data['reveal_submission_feedback']['show_zero_points_immediately'] = (
+                str_to_bool(options['show-zero-points-immediately'])
+            )
+    if 'reveal-model-solutions' in options:
+        data['reveal_model_solutions'] = parse_reveal_rule(
+            options['reveal-model-solutions'],
+            source,
+            line,
+            'reveal-model-solutions',
+        )


### PR DESCRIPTION
# Description

**What?**

Add support to rst-tools to enable the show-zero-points-immediately flag for an exercise. 

**Why?**

Was asked by the teachers. Needs the requisite A+ pull request to function correctly [A+ pr #1389](https://github.com/apluslms/a-plus/pull/1389)

**How?**

Changed revealrule.py parsing


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

[ADD A DESCRIPTION ABOUT WHAT YOU TESTED MANUALLY]

**Did you test the changes in**

- [ ] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [ ] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
